### PR TITLE
fix: auth hang, fields list bug + feat: extensions, --quiet, collections improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
       "schema": {
         "description": "Snapshot, diff, and apply schema changes"
       },
+      "extensions": {
+        "description": "List and manage installed extensions"
+      },
       "server": {
         "description": "Server health and info"
       }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -1,12 +1,10 @@
-import {Command, type Interfaces} from '@oclif/core';
+import { Command, type Interfaces } from '@oclif/core';
 
-import {globalFlags} from './flags/global.js';
-import {
-  isTokenExpired, refreshAndStoreTokens, resolveConnection, type ResolvedConnection,
-} from './lib/auth.js';
-import {createClient, type DirectusClient} from './lib/client.js';
-import {formatOutput, type OutputFormat} from './lib/output.js';
-import {type CommandArgs, DirectusCliError} from './types/index.js';
+import { globalFlags } from './flags/global.js';
+import { isTokenExpired, refreshAndStoreTokens, resolveConnection, type ResolvedConnection } from './lib/auth.js';
+import { createClient, type DirectusClient } from './lib/client.js';
+import { formatOutput, type OutputFormat } from './lib/output.js';
+import { type CommandArgs, DirectusCliError } from './types/index.js';
 
 /**
  * Base command class for all Directus CLI commands.
@@ -29,7 +27,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
    */
   protected get args(): CommandArgs {
     // Access the protected parsedArgs property through unknown cast
-    const cmd = this as unknown as {parsedArgs: unknown};
+    const cmd = this as unknown as { parsedArgs: unknown };
     return cmd.parsedArgs as CommandArgs;
   }
 
@@ -38,14 +36,14 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
    */
   protected get flags(): Interfaces.InferredFlags<T['flags'] & typeof globalFlags> {
     // Access the protected parsedFlags property through unknown cast
-    const cmd = this as unknown as {parsedFlags: unknown};
+    const cmd = this as unknown as { parsedFlags: unknown };
     return cmd.parsedFlags as Interfaces.InferredFlags<T['flags'] & typeof globalFlags>;
   }
 
   /**
    * Handle errors in a consistent way.
    */
-  protected override async catch(error: Error & {exitCode?: number} & {statusCode?: number}): Promise<void> {
+  protected override async catch(error: Error & { exitCode?: number } & { statusCode?: number }): Promise<void> {
     const directusError = DirectusCliError.from(error);
 
     const parts: string[] = [];
@@ -57,7 +55,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     parts.push(directusError.message);
 
     // Access verbose flag carefully - might not be available if init failed
-    const flags = this.flags as unknown as undefined | {verbose?: boolean};
+    const flags = this.flags as unknown as undefined | { verbose?: boolean };
     if (flags?.verbose && directusError.errors) {
       for (const err of directusError.errors) {
         if (err.extensions) {
@@ -66,7 +64,19 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       }
     }
 
-    this.error(parts.join(' '), {exit: directusError.statusCode ?? 1});
+    this.error(parts.join(' '), { exit: directusError.statusCode ?? 1 });
+  }
+
+  /**
+   * Clean up resources after command execution.
+   * Disconnects the Bottleneck limiter so the process can exit cleanly.
+   */
+  protected override async finally(_: Error | undefined): Promise<void> {
+    if (this.client) {
+      await this.client.destroy();
+    }
+
+    await super.finally(_);
   }
 
   /**
@@ -79,8 +89,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     const parsed = await this.parse(this.constructor as typeof Command);
 
     // Store parsed flags and args so the getters work
-    (this as unknown as {parsedFlags: unknown}).parsedFlags = parsed.flags;
-    (this as unknown as {parsedArgs: unknown}).parsedArgs = parsed.args;
+    (this as unknown as { parsedFlags: unknown }).parsedFlags = parsed.flags;
+    (this as unknown as { parsedArgs: unknown }).parsedArgs = parsed.args;
 
     // Resolve connection from flags/env/profile
     this.connection = resolveConnection({
@@ -114,10 +124,12 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
 
   /**
    * Output formatted data based on the --format flag.
+   * Respects --quiet to suppress metadata and non-data output.
    */
-  protected outputFormatted<TData>(data: TData, meta?: {filterCount?: number; totalCount?: number}): void {
+  protected outputFormatted<TData>(data: TData, meta?: { filterCount?: number; totalCount?: number }): void {
     const format = this.flags.format as OutputFormat;
-    const output = formatOutput(data, format, meta);
+    const quiet = this.flags.quiet as boolean | undefined;
+    const output = formatOutput(data, format, meta, quiet);
     this.log(output);
   }
 }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -1,10 +1,12 @@
-import { Command, type Interfaces } from '@oclif/core';
+import {Command, type Interfaces} from '@oclif/core';
 
-import { globalFlags } from './flags/global.js';
-import { isTokenExpired, refreshAndStoreTokens, resolveConnection, type ResolvedConnection } from './lib/auth.js';
-import { createClient, type DirectusClient } from './lib/client.js';
-import { formatOutput, type OutputFormat } from './lib/output.js';
-import { type CommandArgs, DirectusCliError } from './types/index.js';
+import {globalFlags} from './flags/global.js';
+import {
+  isTokenExpired, refreshAndStoreTokens, resolveConnection, type ResolvedConnection,
+} from './lib/auth.js';
+import {createClient, type DirectusClient} from './lib/client.js';
+import {formatOutput, type OutputFormat} from './lib/output.js';
+import {type CommandArgs, DirectusCliError} from './types/index.js';
 
 /**
  * Base command class for all Directus CLI commands.
@@ -27,7 +29,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
    */
   protected get args(): CommandArgs {
     // Access the protected parsedArgs property through unknown cast
-    const cmd = this as unknown as { parsedArgs: unknown };
+    const cmd = this as unknown as {parsedArgs: unknown};
     return cmd.parsedArgs as CommandArgs;
   }
 
@@ -36,14 +38,14 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
    */
   protected get flags(): Interfaces.InferredFlags<T['flags'] & typeof globalFlags> {
     // Access the protected parsedFlags property through unknown cast
-    const cmd = this as unknown as { parsedFlags: unknown };
+    const cmd = this as unknown as {parsedFlags: unknown};
     return cmd.parsedFlags as Interfaces.InferredFlags<T['flags'] & typeof globalFlags>;
   }
 
   /**
    * Handle errors in a consistent way.
    */
-  protected override async catch(error: Error & { exitCode?: number } & { statusCode?: number }): Promise<void> {
+  protected override async catch(error: Error & {exitCode?: number} & {statusCode?: number}): Promise<void> {
     const directusError = DirectusCliError.from(error);
 
     const parts: string[] = [];
@@ -55,7 +57,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     parts.push(directusError.message);
 
     // Access verbose flag carefully - might not be available if init failed
-    const flags = this.flags as unknown as undefined | { verbose?: boolean };
+    const flags = this.flags as unknown as undefined | {verbose?: boolean};
     if (flags?.verbose && directusError.errors) {
       for (const err of directusError.errors) {
         if (err.extensions) {
@@ -64,7 +66,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       }
     }
 
-    this.error(parts.join(' '), { exit: directusError.statusCode ?? 1 });
+    this.error(parts.join(' '), {exit: directusError.statusCode ?? 1});
   }
 
   /**
@@ -89,8 +91,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     const parsed = await this.parse(this.constructor as typeof Command);
 
     // Store parsed flags and args so the getters work
-    (this as unknown as { parsedFlags: unknown }).parsedFlags = parsed.flags;
-    (this as unknown as { parsedArgs: unknown }).parsedArgs = parsed.args;
+    (this as unknown as {parsedFlags: unknown}).parsedFlags = parsed.flags;
+    (this as unknown as {parsedArgs: unknown}).parsedArgs = parsed.args;
 
     // Resolve connection from flags/env/profile
     this.connection = resolveConnection({
@@ -126,7 +128,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
    * Output formatted data based on the --format flag.
    * Respects --quiet to suppress metadata and non-data output.
    */
-  protected outputFormatted<TData>(data: TData, meta?: { filterCount?: number; totalCount?: number }): void {
+  protected outputFormatted<TData>(data: TData, meta?: {filterCount?: number; totalCount?: number}): void {
     const format = this.flags.format as OutputFormat;
     const quiet = this.flags.quiet as boolean | undefined;
     const output = formatOutput(data, format, meta, quiet);

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,6 +1,6 @@
-import { Command, Flags } from '@oclif/core';
+import {Command, Flags} from '@oclif/core';
 
-import { loginAndStoreTokens } from '../../lib/auth.js';
+import {loginAndStoreTokens} from '../../lib/auth.js';
 
 /**
  * Login to a Directus instance.
@@ -34,7 +34,7 @@ export default class AuthLogin extends Command {
   static override summary = 'Login to Directus';
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(AuthLogin);
+    const {flags} = await this.parse(AuthLogin);
 
     await loginAndStoreTokens(flags.profile, flags.email, flags.password, flags.url);
 
@@ -42,6 +42,7 @@ export default class AuthLogin extends Command {
 
     // Force exit: the Directus SDK authentication module and Bottleneck
     // rate limiter keep handles open that prevent Node from exiting cleanly.
+    // eslint-disable-next-line unicorn/no-process-exit
     process.exit(0);
   }
 }

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,6 +1,6 @@
-import {Command, Flags} from '@oclif/core';
+import { Command, Flags } from '@oclif/core';
 
-import {loginAndStoreTokens} from '../../lib/auth.js';
+import { loginAndStoreTokens } from '../../lib/auth.js';
 
 /**
  * Login to a Directus instance.
@@ -34,10 +34,14 @@ export default class AuthLogin extends Command {
   static override summary = 'Login to Directus';
 
   public async run(): Promise<void> {
-    const {flags} = await this.parse(AuthLogin);
+    const { flags } = await this.parse(AuthLogin);
 
     await loginAndStoreTokens(flags.profile, flags.email, flags.password, flags.url);
 
     this.log(`Successfully logged in to profile "${flags.profile}".`);
+
+    // Force exit: the Directus SDK authentication module and Bottleneck
+    // rate limiter keep handles open that prevent Node from exiting cleanly.
+    process.exit(0);
   }
 }

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -1,6 +1,6 @@
-import {Command, Flags} from '@oclif/core';
+import { Command, Flags } from '@oclif/core';
 
-import {logoutAndClearTokens} from '../../lib/auth.js';
+import { logoutAndClearTokens } from '../../lib/auth.js';
 
 /**
  * Logout from a Directus instance.
@@ -18,10 +18,13 @@ export default class AuthLogout extends Command {
   static override summary = 'Logout from Directus';
 
   public async run(): Promise<void> {
-    const {flags} = await this.parse(AuthLogout);
+    const { flags } = await this.parse(AuthLogout);
 
     await logoutAndClearTokens(flags.profile);
 
     this.log(`Successfully logged out from profile "${flags.profile}".`);
+
+    // Force exit: the Directus SDK keeps handles open that prevent clean exit.
+    process.exit(0);
   }
 }

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -1,6 +1,6 @@
-import { Command, Flags } from '@oclif/core';
+import {Command, Flags} from '@oclif/core';
 
-import { logoutAndClearTokens } from '../../lib/auth.js';
+import {logoutAndClearTokens} from '../../lib/auth.js';
 
 /**
  * Logout from a Directus instance.
@@ -18,13 +18,14 @@ export default class AuthLogout extends Command {
   static override summary = 'Logout from Directus';
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(AuthLogout);
+    const {flags} = await this.parse(AuthLogout);
 
     await logoutAndClearTokens(flags.profile);
 
     this.log(`Successfully logged out from profile "${flags.profile}".`);
 
     // Force exit: the Directus SDK keeps handles open that prevent clean exit.
+    // eslint-disable-next-line unicorn/no-process-exit
     process.exit(0);
   }
 }

--- a/src/commands/auth/refresh.ts
+++ b/src/commands/auth/refresh.ts
@@ -1,6 +1,6 @@
-import { Command, Flags } from '@oclif/core';
+import {Command, Flags} from '@oclif/core';
 
-import { refreshAndStoreTokens } from '../../lib/auth.js';
+import {refreshAndStoreTokens} from '../../lib/auth.js';
 
 /**
  * Refresh the access token.
@@ -18,13 +18,14 @@ export default class AuthRefresh extends Command {
   static override summary = 'Refresh access token';
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(AuthRefresh);
+    const {flags} = await this.parse(AuthRefresh);
 
     const success = await refreshAndStoreTokens(flags.profile);
 
     if (success) {
       this.log(`Successfully refreshed token for profile "${flags.profile}".`);
       // Force exit: the Directus SDK keeps handles open that prevent clean exit.
+      // eslint-disable-next-line unicorn/no-process-exit
       process.exit(0);
     } else {
       this.error(`Failed to refresh token for profile "${flags.profile}". Try logging in again.`);

--- a/src/commands/auth/refresh.ts
+++ b/src/commands/auth/refresh.ts
@@ -1,6 +1,6 @@
-import {Command, Flags} from '@oclif/core';
+import { Command, Flags } from '@oclif/core';
 
-import {refreshAndStoreTokens} from '../../lib/auth.js';
+import { refreshAndStoreTokens } from '../../lib/auth.js';
 
 /**
  * Refresh the access token.
@@ -18,12 +18,14 @@ export default class AuthRefresh extends Command {
   static override summary = 'Refresh access token';
 
   public async run(): Promise<void> {
-    const {flags} = await this.parse(AuthRefresh);
+    const { flags } = await this.parse(AuthRefresh);
 
     const success = await refreshAndStoreTokens(flags.profile);
 
     if (success) {
       this.log(`Successfully refreshed token for profile "${flags.profile}".`);
+      // Force exit: the Directus SDK keeps handles open that prevent clean exit.
+      process.exit(0);
     } else {
       this.error(`Failed to refresh token for profile "${flags.profile}". Try logging in again.`);
     }

--- a/src/commands/collections/list.ts
+++ b/src/commands/collections/list.ts
@@ -1,33 +1,47 @@
-import {readCollections} from '@directus/sdk';
+import { readCollections } from '@directus/sdk';
+import { Flags } from '@oclif/core';
 
-import type {SdkRestCommand} from '../../types/index.js';
+import type { SdkRestCommand } from '../../types/index.js';
 
-import {BaseCommand} from '../../base-command.js';
+import { BaseCommand } from '../../base-command.js';
 
 /**
  * List all collections in the Directus instance.
  */
 export default class CollectionsList extends BaseCommand<typeof CollectionsList> {
   static override description = 'List all collections in the Directus instance';
-  static override examples = ['<%= config.bin %> <%= command.id %>', '<%= config.bin %> <%= command.id %> -p prod'];
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> -p prod',
+    '<%= config.bin %> <%= command.id %> --names-only',
+  ];
   static override flags = {
     ...BaseCommand.baseFlags,
+    'names-only': Flags.boolean({
+      default: false,
+      description: 'Return only collection names as a flat array',
+    }),
   };
   static override summary = 'List collections';
 
   public async run(): Promise<void> {
+    const { flags } = await this.parse(CollectionsList);
     const sdkCommand = readCollections() as unknown as SdkRestCommand<unknown[]>;
     const result = await this.client.request(sdkCommand);
 
-    // Extract just the collection names for display
-    const collections = Array.isArray(result) ? result : ((result as {data?: unknown[]}).data ?? []);
-    const collectionNames = collections
-    .map((c: unknown) => {
-      const collection = c as {collection?: string};
-      return collection.collection;
-    })
-    .filter(Boolean);
+    const collections = Array.isArray(result) ? result : ((result as { data?: unknown[] }).data ?? []);
 
-    this.outputFormatted(collectionNames);
+    if (flags['names-only']) {
+      // Extract just the collection names for display
+      const collectionNames = collections
+        .map((c: unknown) => {
+          const collection = c as { collection?: string };
+          return collection.collection;
+        })
+        .filter(Boolean);
+      this.outputFormatted(collectionNames);
+    } else {
+      this.outputFormatted(collections);
+    }
   }
 }

--- a/src/commands/collections/list.ts
+++ b/src/commands/collections/list.ts
@@ -1,9 +1,9 @@
-import { readCollections } from '@directus/sdk';
-import { Flags } from '@oclif/core';
+import {readCollections} from '@directus/sdk';
+import {Flags} from '@oclif/core';
 
-import type { SdkRestCommand } from '../../types/index.js';
+import type {SdkRestCommand} from '../../types/index.js';
 
-import { BaseCommand } from '../../base-command.js';
+import {BaseCommand} from '../../base-command.js';
 
 /**
  * List all collections in the Directus instance.
@@ -25,20 +25,20 @@ export default class CollectionsList extends BaseCommand<typeof CollectionsList>
   static override summary = 'List collections';
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(CollectionsList);
+    const {flags} = await this.parse(CollectionsList);
     const sdkCommand = readCollections() as unknown as SdkRestCommand<unknown[]>;
     const result = await this.client.request(sdkCommand);
 
-    const collections = Array.isArray(result) ? result : ((result as { data?: unknown[] }).data ?? []);
+    const collections = Array.isArray(result) ? result : ((result as {data?: unknown[]}).data ?? []);
 
     if (flags['names-only']) {
       // Extract just the collection names for display
       const collectionNames = collections
-        .map((c: unknown) => {
-          const collection = c as { collection?: string };
-          return collection.collection;
-        })
-        .filter(Boolean);
+      .map((c: unknown) => {
+        const collection = c as {collection?: string};
+        return collection.collection;
+      })
+      .filter(Boolean);
       this.outputFormatted(collectionNames);
     } else {
       this.outputFormatted(collections);

--- a/src/commands/extensions/list.ts
+++ b/src/commands/extensions/list.ts
@@ -1,0 +1,71 @@
+import { readExtensions } from '@directus/sdk';
+import { Flags } from '@oclif/core';
+
+import type { SdkRestCommand } from '../../types/index.js';
+
+import { BaseCommand } from '../../base-command.js';
+
+/**
+ * List all installed extensions.
+ */
+export default class ExtensionsList extends BaseCommand<typeof ExtensionsList> {
+  static override args = {};
+  static override description = 'List all installed extensions with name, type, version, and enabled status';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --type hook',
+    '<%= config.bin %> <%= command.id %> --enabled',
+    '<%= config.bin %> <%= command.id %> -f table',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    enabled: Flags.boolean({
+      description: 'Show only enabled extensions',
+    }),
+    type: Flags.string({
+      description:
+        'Filter by extension type (interface, display, layout, module, panel, hook, endpoint, operation, bundle)',
+      helpValue: '<type>',
+    }),
+  };
+  static override summary = 'List extensions';
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(ExtensionsList);
+
+    const sdkCommand = readExtensions() as unknown as SdkRestCommand<unknown[]>;
+    const result = await this.client.request(sdkCommand);
+
+    let data = Array.isArray(result) ? result : ((result as { data?: unknown[] }).data ?? []);
+
+    // Flatten extensions into a more useful shape for display
+    data = data.map((ext: unknown) => {
+      const e = ext as {
+        bundle?: null | string;
+        meta?: { enabled?: boolean };
+        name?: string;
+        schema?: { local?: boolean; type?: string; version?: string } | null;
+      };
+      return {
+        bundle: e.bundle ?? null,
+        enabled: e.meta?.enabled ?? false,
+        local: e.schema?.local ?? false,
+        name: e.name ?? 'unknown',
+        type: e.schema?.type ?? 'unknown',
+        version: e.schema?.version ?? '-',
+      };
+    });
+
+    // Apply filters
+    if (flags.type) {
+      const filterType = flags.type.toLowerCase();
+      data = data.filter((e: unknown) => (e as { type: string }).type === filterType);
+    }
+
+    if (flags.enabled) {
+      data = data.filter((e: unknown) => (e as { enabled: boolean }).enabled);
+    }
+
+    this.outputFormatted(data);
+  }
+}

--- a/src/commands/extensions/list.ts
+++ b/src/commands/extensions/list.ts
@@ -1,9 +1,9 @@
-import { readExtensions } from '@directus/sdk';
-import { Flags } from '@oclif/core';
+import {readExtensions} from '@directus/sdk';
+import {Flags} from '@oclif/core';
 
-import type { SdkRestCommand } from '../../types/index.js';
+import type {SdkRestCommand} from '../../types/index.js';
 
-import { BaseCommand } from '../../base-command.js';
+import {BaseCommand} from '../../base-command.js';
 
 /**
  * List all installed extensions.
@@ -31,20 +31,20 @@ export default class ExtensionsList extends BaseCommand<typeof ExtensionsList> {
   static override summary = 'List extensions';
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(ExtensionsList);
+    const {flags} = await this.parse(ExtensionsList);
 
     const sdkCommand = readExtensions() as unknown as SdkRestCommand<unknown[]>;
     const result = await this.client.request(sdkCommand);
 
-    let data = Array.isArray(result) ? result : ((result as { data?: unknown[] }).data ?? []);
+    let data = Array.isArray(result) ? result : ((result as {data?: unknown[]}).data ?? []);
 
     // Flatten extensions into a more useful shape for display
     data = data.map((ext: unknown) => {
       const e = ext as {
         bundle?: null | string;
-        meta?: { enabled?: boolean };
+        meta?: {enabled?: boolean};
         name?: string;
-        schema?: { local?: boolean; type?: string; version?: string } | null;
+        schema?: null | {local?: boolean; type?: string; version?: string};
       };
       return {
         bundle: e.bundle ?? null,
@@ -59,11 +59,11 @@ export default class ExtensionsList extends BaseCommand<typeof ExtensionsList> {
     // Apply filters
     if (flags.type) {
       const filterType = flags.type.toLowerCase();
-      data = data.filter((e: unknown) => (e as { type: string }).type === filterType);
+      data = data.filter((e: unknown) => (e as {type: string}).type === filterType);
     }
 
     if (flags.enabled) {
-      data = data.filter((e: unknown) => (e as { enabled: boolean }).enabled);
+      data = data.filter((e: unknown) => (e as {enabled: boolean}).enabled);
     }
 
     this.outputFormatted(data);

--- a/src/commands/extensions/toggle.ts
+++ b/src/commands/extensions/toggle.ts
@@ -1,0 +1,58 @@
+import { updateExtension } from '@directus/sdk';
+import { Args, Flags } from '@oclif/core';
+
+import type { SdkRestCommand } from '../../types/index.js';
+
+import { BaseCommand } from '../../base-command.js';
+
+/**
+ * Enable or disable an extension.
+ */
+export default class ExtensionsToggle extends BaseCommand<typeof ExtensionsToggle> {
+  static override args = {
+    name: Args.string({
+      description: 'Extension name',
+      required: true,
+    }),
+  };
+  static override description = 'Enable or disable an extension by name';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> my-extension --enable',
+    '<%= config.bin %> <%= command.id %> my-extension --disable',
+    '<%= config.bin %> <%= command.id %> my-extension --enable --bundle my-bundle',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    bundle: Flags.string({
+      description: 'Bundle name if the extension belongs to a bundle',
+      helpValue: '<bundle>',
+    }),
+    disable: Flags.boolean({
+      description: 'Disable the extension',
+      exclusive: ['enable'],
+    }),
+    enable: Flags.boolean({
+      description: 'Enable the extension',
+      exclusive: ['disable'],
+    }),
+  };
+  static override summary = 'Enable or disable an extension';
+
+  public async run(): Promise<void> {
+    const { args, flags } = await this.parse(ExtensionsToggle);
+
+    if (!flags.enable && !flags.disable) {
+      this.error('You must specify either --enable or --disable');
+    }
+
+    const enabled = Boolean(flags.enable);
+    const bundle = flags.bundle ?? null;
+
+    const sdkCommand = updateExtension(bundle, args.name, {
+      meta: { enabled },
+    }) as unknown as SdkRestCommand<unknown>;
+
+    const result = await this.client.request(sdkCommand);
+    this.outputFormatted(result);
+  }
+}

--- a/src/commands/extensions/toggle.ts
+++ b/src/commands/extensions/toggle.ts
@@ -1,9 +1,9 @@
-import { updateExtension } from '@directus/sdk';
-import { Args, Flags } from '@oclif/core';
+import {updateExtension} from '@directus/sdk';
+import {Args, Flags} from '@oclif/core';
 
-import type { SdkRestCommand } from '../../types/index.js';
+import type {SdkRestCommand} from '../../types/index.js';
 
-import { BaseCommand } from '../../base-command.js';
+import {BaseCommand} from '../../base-command.js';
 
 /**
  * Enable or disable an extension.
@@ -39,7 +39,7 @@ export default class ExtensionsToggle extends BaseCommand<typeof ExtensionsToggl
   static override summary = 'Enable or disable an extension';
 
   public async run(): Promise<void> {
-    const { args, flags } = await this.parse(ExtensionsToggle);
+    const {args, flags} = await this.parse(ExtensionsToggle);
 
     if (!flags.enable && !flags.disable) {
       this.error('You must specify either --enable or --disable');
@@ -49,7 +49,7 @@ export default class ExtensionsToggle extends BaseCommand<typeof ExtensionsToggl
     const bundle = flags.bundle ?? null;
 
     const sdkCommand = updateExtension(bundle, args.name, {
-      meta: { enabled },
+      meta: {enabled},
     }) as unknown as SdkRestCommand<unknown>;
 
     const result = await this.client.request(sdkCommand);

--- a/src/commands/fields/list.ts
+++ b/src/commands/fields/list.ts
@@ -1,17 +1,18 @@
-import {readFields} from '@directus/sdk';
-import {Flags} from '@oclif/core';
+import { readFieldsByCollection, readFields } from '@directus/sdk';
+import { Flags } from '@oclif/core';
 
-import type {SdkRestCommand} from '../../types/index.js';
+import type { SdkRestCommand } from '../../types/index.js';
 
-import {BaseCommand} from '../../base-command.js';
+import { BaseCommand } from '../../base-command.js';
 
 /**
- * List fields for a collection.
+ * List fields, optionally filtered by collection.
  */
 export default class FieldsList extends BaseCommand<typeof FieldsList> {
   static override args = {};
-  static override description = 'List fields for a collection';
+  static override description = 'List fields for a collection, or all fields across all collections';
   static override examples = [
+    '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --collection cases',
     '<%= config.bin %> <%= command.id %> --collection cases --fields field,collection,type',
   ];
@@ -19,17 +20,26 @@ export default class FieldsList extends BaseCommand<typeof FieldsList> {
     ...BaseCommand.baseFlags,
     collection: Flags.string({
       char: 'c',
-      description: 'Collection name',
-      required: true,
+      description: 'Collection name (omit to list all fields across all collections)',
     }),
   };
   static override summary = 'List fields';
 
   public async run(): Promise<void> {
-    const sdkCommand = readFields() as unknown as SdkRestCommand<unknown[]>;
-    const result = await this.client.request(sdkCommand);
+    const { flags } = await this.parse(FieldsList);
 
-    const data = Array.isArray(result) ? result : ((result as {data?: unknown[]}).data ?? []);
+    let result: unknown;
+    if (flags.collection) {
+      // Fetch fields for a specific collection
+      const sdkCommand = readFieldsByCollection(flags.collection) as unknown as SdkRestCommand<unknown[]>;
+      result = await this.client.request(sdkCommand);
+    } else {
+      // Fetch all fields across all collections
+      const sdkCommand = readFields() as unknown as SdkRestCommand<unknown[]>;
+      result = await this.client.request(sdkCommand);
+    }
+
+    const data = Array.isArray(result) ? result : ((result as { data?: unknown[] }).data ?? []);
     this.outputFormatted(data);
   }
 }

--- a/src/commands/fields/list.ts
+++ b/src/commands/fields/list.ts
@@ -1,9 +1,9 @@
-import { readFieldsByCollection, readFields } from '@directus/sdk';
-import { Flags } from '@oclif/core';
+import {readFields, readFieldsByCollection} from '@directus/sdk';
+import {Flags} from '@oclif/core';
 
-import type { SdkRestCommand } from '../../types/index.js';
+import type {SdkRestCommand} from '../../types/index.js';
 
-import { BaseCommand } from '../../base-command.js';
+import {BaseCommand} from '../../base-command.js';
 
 /**
  * List fields, optionally filtered by collection.
@@ -26,7 +26,7 @@ export default class FieldsList extends BaseCommand<typeof FieldsList> {
   static override summary = 'List fields';
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(FieldsList);
+    const {flags} = await this.parse(FieldsList);
 
     let result: unknown;
     if (flags.collection) {
@@ -39,7 +39,7 @@ export default class FieldsList extends BaseCommand<typeof FieldsList> {
       result = await this.client.request(sdkCommand);
     }
 
-    const data = Array.isArray(result) ? result : ((result as { data?: unknown[] }).data ?? []);
+    const data = Array.isArray(result) ? result : ((result as {data?: unknown[]}).data ?? []);
     this.outputFormatted(data);
   }
 }

--- a/src/flags/global.ts
+++ b/src/flags/global.ts
@@ -1,6 +1,6 @@
-import { Flags } from '@oclif/core';
+import {Flags} from '@oclif/core';
 
-import type { OutputFormat } from '../lib/output.js';
+import type {OutputFormat} from '../lib/output.js';
 
 /**
  * Global flags available on all commands.

--- a/src/flags/global.ts
+++ b/src/flags/global.ts
@@ -1,6 +1,6 @@
-import {Flags} from '@oclif/core';
+import { Flags } from '@oclif/core';
 
-import type {OutputFormat} from '../lib/output.js';
+import type { OutputFormat } from '../lib/output.js';
 
 /**
  * Global flags available on all commands.
@@ -17,6 +17,11 @@ export const globalFlags = {
     description: 'Profile name from config',
     env: 'DIRECTUS_PROFILE',
     helpValue: '<name>',
+  }),
+  quiet: Flags.boolean({
+    char: 'q',
+    default: false,
+    description: 'Suppress non-data output (headers, footers, status messages)',
   }),
   token: Flags.string({
     char: 't',

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,7 +1,9 @@
-import { authentication, type AuthenticationClient, createDirectus, rest, type RestClient } from '@directus/sdk';
+import {
+  authentication, type AuthenticationClient, createDirectus, rest, type RestClient,
+} from '@directus/sdk';
 import Bottleneck from 'bottleneck';
 
-import { DirectusCliError, type SdkRestCommand } from '../types/index.js';
+import {DirectusCliError, type SdkRestCommand} from '../types/index.js';
 
 // Global rate limiter: 10 concurrent, 50 req/s reservoir
 const limiter = new Bottleneck({
@@ -41,8 +43,8 @@ export class DirectusClient {
     this.verbose = options.verbose ?? false;
 
     const builder = createDirectus<unknown>(options.url)
-      .with(rest())
-      .with(authentication('json', { credentials: 'omit' }));
+    .with(rest())
+    .with(authentication('json', {credentials: 'omit'}));
 
     // Cast through unknown to handle type mismatch between builder and expected type
     this.client = builder as unknown as AuthenticationClient<unknown> & RestClient<unknown>;
@@ -83,9 +85,9 @@ export class DirectusClient {
   async login(
     email: string,
     password: string,
-  ): Promise<{ accessToken: string; expires?: number; refreshToken?: string }> {
+  ): Promise<{accessToken: string; expires?: number; refreshToken?: string}> {
     try {
-      const result = await this.client.login({ email, password });
+      const result = await this.client.login({email, password});
       if (!result.access_token) {
         throw new DirectusCliError('Login failed: no access token received', 401);
       }
@@ -115,7 +117,7 @@ export class DirectusClient {
   /**
    * Refresh the access token using the stored refresh token.
    */
-  async refreshAccessToken(): Promise<undefined | { accessToken: string; expires?: number; refreshToken?: string }> {
+  async refreshAccessToken(): Promise<undefined | {accessToken: string; expires?: number; refreshToken?: string}> {
     if (!this.refreshToken) {
       return undefined;
     }
@@ -193,7 +195,7 @@ export class DirectusClient {
  * Sleep for a given number of milliseconds.
  */
 function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     setTimeout(resolve, ms);
   });
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,9 +1,7 @@
-import {
-  authentication, type AuthenticationClient, createDirectus, rest, type RestClient,
-} from '@directus/sdk';
+import { authentication, type AuthenticationClient, createDirectus, rest, type RestClient } from '@directus/sdk';
 import Bottleneck from 'bottleneck';
 
-import {DirectusCliError, type SdkRestCommand} from '../types/index.js';
+import { DirectusCliError, type SdkRestCommand } from '../types/index.js';
 
 // Global rate limiter: 10 concurrent, 50 req/s reservoir
 const limiter = new Bottleneck({
@@ -43,8 +41,8 @@ export class DirectusClient {
     this.verbose = options.verbose ?? false;
 
     const builder = createDirectus<unknown>(options.url)
-    .with(rest())
-    .with(authentication('json', {credentials: 'omit'}));
+      .with(rest())
+      .with(authentication('json', { credentials: 'omit' }));
 
     // Cast through unknown to handle type mismatch between builder and expected type
     this.client = builder as unknown as AuthenticationClient<unknown> & RestClient<unknown>;
@@ -55,6 +53,14 @@ export class DirectusClient {
     } else if (options.accessToken) {
       this.client.setToken(options.accessToken);
     }
+  }
+
+  /**
+   * Disconnect and clean up resources (Bottleneck limiter).
+   * Call this when done with the client to allow the process to exit cleanly.
+   */
+  async destroy(): Promise<void> {
+    await limiter.disconnect();
   }
 
   /**
@@ -77,9 +83,9 @@ export class DirectusClient {
   async login(
     email: string,
     password: string,
-  ): Promise<{accessToken: string; expires?: number; refreshToken?: string}> {
+  ): Promise<{ accessToken: string; expires?: number; refreshToken?: string }> {
     try {
-      const result = await this.client.login({email, password});
+      const result = await this.client.login({ email, password });
       if (!result.access_token) {
         throw new DirectusCliError('Login failed: no access token received', 401);
       }
@@ -109,7 +115,7 @@ export class DirectusClient {
   /**
    * Refresh the access token using the stored refresh token.
    */
-  async refreshAccessToken(): Promise<undefined | {accessToken: string; expires?: number; refreshToken?: string}> {
+  async refreshAccessToken(): Promise<undefined | { accessToken: string; expires?: number; refreshToken?: string }> {
     if (!this.refreshToken) {
       return undefined;
     }
@@ -187,7 +193,7 @@ export class DirectusClient {
  * Sleep for a given number of milliseconds.
  */
 function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
 }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -20,40 +20,40 @@ export function formatError(error: Error): string {
 export function formatOutput(
   data: unknown,
   format: OutputFormat,
-  meta?: { filterCount?: number; totalCount?: number },
+  meta?: {filterCount?: number; totalCount?: number},
   quiet?: boolean,
 ): string {
   const effectiveMeta = quiet ? undefined : meta;
   switch (format) {
-    case 'json': {
-      return quiet ? JSON.stringify(data, null, 2) : formatJson(data, effectiveMeta);
-    }
+  case 'json': {
+    return quiet ? JSON.stringify(data, null, 2) : formatJson(data, effectiveMeta);
+  }
 
-    case 'table': {
-      return formatTable(data, effectiveMeta);
-    }
+  case 'table': {
+    return formatTable(data, effectiveMeta);
+  }
 
-    case 'yaml': {
-      return quiet ? YAML.stringify(data) : formatYaml(data, effectiveMeta);
-    }
+  case 'yaml': {
+    return quiet ? YAML.stringify(data) : formatYaml(data, effectiveMeta);
+  }
 
-    default: {
-      return quiet ? JSON.stringify(data, null, 2) : formatJson(data, effectiveMeta);
-    }
+  default: {
+    return quiet ? JSON.stringify(data, null, 2) : formatJson(data, effectiveMeta);
+  }
   }
 }
 
 /**
  * Format as JSON with optional metadata.
  */
-function formatJson(data: unknown, meta?: { filterCount?: number; totalCount?: number }): string {
-  const output: Record<string, unknown> = { data };
+function formatJson(data: unknown, meta?: {filterCount?: number; totalCount?: number}): string {
+  const output: Record<string, unknown> = {data};
   if (meta?.totalCount !== undefined) {
     output.meta = {
       // eslint-disable-next-line camelcase
       total_count: meta.totalCount,
       // eslint-disable-next-line camelcase
-      ...(meta.filterCount !== undefined && { filter_count: meta.filterCount }),
+      ...(meta.filterCount !== undefined && {filter_count: meta.filterCount}),
     };
   }
 
@@ -63,7 +63,7 @@ function formatJson(data: unknown, meta?: { filterCount?: number; totalCount?: n
 /**
  * Format as a table. Only works for array data.
  */
-function formatTable(data: unknown, meta?: { filterCount?: number; totalCount?: number }): string {
+function formatTable(data: unknown, meta?: {filterCount?: number; totalCount?: number}): string {
   if (!Array.isArray(data)) {
     // Fallback to JSON for non-array data
     return formatJson(data, meta);
@@ -83,7 +83,7 @@ function formatTable(data: unknown, meta?: { filterCount?: number; totalCount?: 
 
   // Build table
   const table = new Table({
-    head: columns.map((col) => truncate(col, 20)),
+    head: columns.map(col => truncate(col, 20)),
     wordWrap: true,
     wrapOnWordBoundary: false,
   });
@@ -91,7 +91,7 @@ function formatTable(data: unknown, meta?: { filterCount?: number; totalCount?: 
   for (const item of data) {
     if (typeof item !== 'object' || item === null) continue;
 
-    const row = columns.map((col) => {
+    const row = columns.map(col => {
       const value = (item as Record<string, unknown>)[col];
       return formatCellValue(value, 30);
     });
@@ -114,14 +114,14 @@ function formatTable(data: unknown, meta?: { filterCount?: number; totalCount?: 
 /**
  * Format as YAML with optional metadata.
  */
-function formatYaml(data: unknown, meta?: { filterCount?: number; totalCount?: number }): string {
-  const output: Record<string, unknown> = { data };
+function formatYaml(data: unknown, meta?: {filterCount?: number; totalCount?: number}): string {
+  const output: Record<string, unknown> = {data};
   if (meta?.totalCount !== undefined) {
     output.meta = {
       // eslint-disable-next-line camelcase
       total_count: meta.totalCount,
       // eslint-disable-next-line camelcase
-      ...(meta.filterCount !== undefined && { filter_count: meta.filterCount }),
+      ...(meta.filterCount !== undefined && {filter_count: meta.filterCount}),
     };
   }
 

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -15,42 +15,45 @@ export function formatError(error: Error): string {
 
 /**
  * Format data for output based on the specified format.
+ * When quiet is true, suppresses metadata (counts, footers) and outputs only the data payload.
  */
 export function formatOutput(
   data: unknown,
   format: OutputFormat,
-  meta?: {filterCount?: number; totalCount?: number},
+  meta?: { filterCount?: number; totalCount?: number },
+  quiet?: boolean,
 ): string {
+  const effectiveMeta = quiet ? undefined : meta;
   switch (format) {
-  case 'json': {
-    return formatJson(data, meta);
-  }
+    case 'json': {
+      return quiet ? JSON.stringify(data, null, 2) : formatJson(data, effectiveMeta);
+    }
 
-  case 'table': {
-    return formatTable(data, meta);
-  }
+    case 'table': {
+      return formatTable(data, effectiveMeta);
+    }
 
-  case 'yaml': {
-    return formatYaml(data, meta);
-  }
+    case 'yaml': {
+      return quiet ? YAML.stringify(data) : formatYaml(data, effectiveMeta);
+    }
 
-  default: {
-    return formatJson(data, meta);
-  }
+    default: {
+      return quiet ? JSON.stringify(data, null, 2) : formatJson(data, effectiveMeta);
+    }
   }
 }
 
 /**
  * Format as JSON with optional metadata.
  */
-function formatJson(data: unknown, meta?: {filterCount?: number; totalCount?: number}): string {
-  const output: Record<string, unknown> = {data};
+function formatJson(data: unknown, meta?: { filterCount?: number; totalCount?: number }): string {
+  const output: Record<string, unknown> = { data };
   if (meta?.totalCount !== undefined) {
     output.meta = {
       // eslint-disable-next-line camelcase
       total_count: meta.totalCount,
       // eslint-disable-next-line camelcase
-      ...(meta.filterCount !== undefined && {filter_count: meta.filterCount}),
+      ...(meta.filterCount !== undefined && { filter_count: meta.filterCount }),
     };
   }
 
@@ -60,7 +63,7 @@ function formatJson(data: unknown, meta?: {filterCount?: number; totalCount?: nu
 /**
  * Format as a table. Only works for array data.
  */
-function formatTable(data: unknown, meta?: {filterCount?: number; totalCount?: number}): string {
+function formatTable(data: unknown, meta?: { filterCount?: number; totalCount?: number }): string {
   if (!Array.isArray(data)) {
     // Fallback to JSON for non-array data
     return formatJson(data, meta);
@@ -80,7 +83,7 @@ function formatTable(data: unknown, meta?: {filterCount?: number; totalCount?: n
 
   // Build table
   const table = new Table({
-    head: columns.map(col => truncate(col, 20)),
+    head: columns.map((col) => truncate(col, 20)),
     wordWrap: true,
     wrapOnWordBoundary: false,
   });
@@ -88,7 +91,7 @@ function formatTable(data: unknown, meta?: {filterCount?: number; totalCount?: n
   for (const item of data) {
     if (typeof item !== 'object' || item === null) continue;
 
-    const row = columns.map(col => {
+    const row = columns.map((col) => {
       const value = (item as Record<string, unknown>)[col];
       return formatCellValue(value, 30);
     });
@@ -111,14 +114,14 @@ function formatTable(data: unknown, meta?: {filterCount?: number; totalCount?: n
 /**
  * Format as YAML with optional metadata.
  */
-function formatYaml(data: unknown, meta?: {filterCount?: number; totalCount?: number}): string {
-  const output: Record<string, unknown> = {data};
+function formatYaml(data: unknown, meta?: { filterCount?: number; totalCount?: number }): string {
+  const output: Record<string, unknown> = { data };
   if (meta?.totalCount !== undefined) {
     output.meta = {
       // eslint-disable-next-line camelcase
       total_count: meta.totalCount,
       // eslint-disable-next-line camelcase
-      ...(meta.filterCount !== undefined && {filter_count: meta.filterCount}),
+      ...(meta.filterCount !== undefined && { filter_count: meta.filterCount }),
     };
   }
 


### PR DESCRIPTION
## Summary

Bug fixes and new features from real-world usage testing. Semantic-release will produce a **minor** bump (0.1.0 → 0.2.0) due to the `feat:` commit.

## Bug Fixes

- **`auth login` hangs after success** — The Directus SDK `authentication('json')` module and Bottleneck rate limiter keep Node handles open. Added `process.exit(0)` to auth commands (login, logout, refresh) and a `destroy()` method on `DirectusClient` that shuts down the Bottleneck limiter. `BaseCommand.finally()` now calls `destroy()` automatically for all other commands.
- **`fields list --collection` required but unused** — The flag was declared `required: true` but never passed to the SDK call. Now optional: omit it to get all fields across all collections, or provide it to scope to a single collection (uses `readFieldsByCollection()` from the SDK).

## New Features

- **`extensions list`** — Lists installed extensions with name, type, version, enabled/local status. Supports `--type <type>` and `--enabled` filters.
- **`extensions toggle <name>`** — Enable/disable extensions by name via `--enable`/`--disable` flags. Supports `--bundle` for bundled extensions.
- **`--quiet` (`-q`) global flag** — Suppresses metadata wrappers. JSON output returns the raw data array instead of `{"data": [...], "meta": {...}}`. Ideal for piping to `jq`.
- **`collections list` improvements** — Now returns full collection objects by default (consistent with other list commands). `--names-only` flag restores the old flat-array-of-names behavior.

## Tests

All 32 existing tests pass. Pre-commit hooks passed on both commits.