### PR TITLE
feat: add extensions commands, --quiet flag, and collections --names-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
       "schema": {
         "description": "Snapshot, diff, and apply schema changes"
       },
+      "extensions": {
+        "description": "List and manage installed extensions"
+      },
       "server": {
         "description": "Server health and info"
       }

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -114,7 +114,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
 
   /**
    * Output formatted data based on the --format flag.
-   * Respects --quiet to suppress metadata and non-data output.
+   * Respects --quiet to suppress output metadata (for example, counts/footers)
+   * and return payload-only output for structured formats such as json/yaml.
    */
   protected outputFormatted<TData>(data: TData, meta?: {filterCount?: number; totalCount?: number}): void {
     const format = this.flags.format as OutputFormat;

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -114,10 +114,12 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
 
   /**
    * Output formatted data based on the --format flag.
+   * Respects --quiet to suppress metadata and non-data output.
    */
   protected outputFormatted<TData>(data: TData, meta?: {filterCount?: number; totalCount?: number}): void {
     const format = this.flags.format as OutputFormat;
-    const output = formatOutput(data, format, meta);
+    const quiet = this.flags.quiet as boolean | undefined;
+    const output = formatOutput(data, format, meta, quiet);
     this.log(output);
   }
 }

--- a/src/commands/collections/list.ts
+++ b/src/commands/collections/list.ts
@@ -1,4 +1,5 @@
 import {readCollections} from '@directus/sdk';
+import {Flags} from '@oclif/core';
 
 import type {SdkRestCommand} from '../../types/index.js';
 
@@ -9,25 +10,38 @@ import {BaseCommand} from '../../base-command.js';
  */
 export default class CollectionsList extends BaseCommand<typeof CollectionsList> {
   static override description = 'List all collections in the Directus instance';
-  static override examples = ['<%= config.bin %> <%= command.id %>', '<%= config.bin %> <%= command.id %> -p prod'];
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> -p prod',
+    '<%= config.bin %> <%= command.id %> --names-only',
+  ];
   static override flags = {
     ...BaseCommand.baseFlags,
+    'names-only': Flags.boolean({
+      default: false,
+      description: 'Return only collection names as a flat array',
+    }),
   };
   static override summary = 'List collections';
 
   public async run(): Promise<void> {
+    const {flags} = await this.parse(CollectionsList);
     const sdkCommand = readCollections() as unknown as SdkRestCommand<unknown[]>;
     const result = await this.client.request(sdkCommand);
 
-    // Extract just the collection names for display
     const collections = Array.isArray(result) ? result : ((result as {data?: unknown[]}).data ?? []);
-    const collectionNames = collections
-    .map((c: unknown) => {
-      const collection = c as {collection?: string};
-      return collection.collection;
-    })
-    .filter(Boolean);
 
-    this.outputFormatted(collectionNames);
+    if (flags['names-only']) {
+      // Extract just the collection names for display
+      const collectionNames = collections
+      .map((c: unknown) => {
+        const collection = c as {collection?: string};
+        return collection.collection;
+      })
+      .filter(Boolean);
+      this.outputFormatted(collectionNames);
+    } else {
+      this.outputFormatted(collections);
+    }
   }
 }

--- a/src/commands/extensions/list.ts
+++ b/src/commands/extensions/list.ts
@@ -1,0 +1,71 @@
+import {readExtensions} from '@directus/sdk';
+import {Flags} from '@oclif/core';
+
+import type {SdkRestCommand} from '../../types/index.js';
+
+import {BaseCommand} from '../../base-command.js';
+
+/**
+ * List all installed extensions.
+ */
+export default class ExtensionsList extends BaseCommand<typeof ExtensionsList> {
+  static override args = {};
+  static override description = 'List all installed extensions with name, type, version, and enabled status';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --type hook',
+    '<%= config.bin %> <%= command.id %> --enabled',
+    '<%= config.bin %> <%= command.id %> -f table',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    enabled: Flags.boolean({
+      description: 'Show only enabled extensions',
+    }),
+    type: Flags.string({
+      description:
+        'Filter by extension type (interface, display, layout, module, panel, hook, endpoint, operation, bundle)',
+      helpValue: '<type>',
+    }),
+  };
+  static override summary = 'List extensions';
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(ExtensionsList);
+
+    const sdkCommand = readExtensions() as unknown as SdkRestCommand<unknown[]>;
+    const result = await this.client.request(sdkCommand);
+
+    let data = Array.isArray(result) ? result : ((result as {data?: unknown[]}).data ?? []);
+
+    // Flatten extensions into a more useful shape for display
+    data = data.map((ext: unknown) => {
+      const e = ext as {
+        bundle?: null | string;
+        meta?: {enabled?: boolean};
+        name?: string;
+        schema?: null | {local?: boolean; type?: string; version?: string};
+      };
+      return {
+        bundle: e.bundle ?? null,
+        enabled: e.meta?.enabled ?? false,
+        local: e.schema?.local ?? false,
+        name: e.name ?? 'unknown',
+        type: e.schema?.type ?? 'unknown',
+        version: e.schema?.version ?? '-',
+      };
+    });
+
+    // Apply filters
+    if (flags.type) {
+      const filterType = flags.type.toLowerCase();
+      data = data.filter((e: unknown) => (e as {type: string}).type === filterType);
+    }
+
+    if (flags.enabled) {
+      data = data.filter((e: unknown) => (e as {enabled: boolean}).enabled);
+    }
+
+    this.outputFormatted(data);
+  }
+}

--- a/src/commands/extensions/toggle.ts
+++ b/src/commands/extensions/toggle.ts
@@ -1,0 +1,58 @@
+import {updateExtension} from '@directus/sdk';
+import {Args, Flags} from '@oclif/core';
+
+import type {SdkRestCommand} from '../../types/index.js';
+
+import {BaseCommand} from '../../base-command.js';
+
+/**
+ * Enable or disable an extension.
+ */
+export default class ExtensionsToggle extends BaseCommand<typeof ExtensionsToggle> {
+  static override args = {
+    name: Args.string({
+      description: 'Extension name',
+      required: true,
+    }),
+  };
+  static override description = 'Enable or disable an extension by name';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> my-extension --enable',
+    '<%= config.bin %> <%= command.id %> my-extension --disable',
+    '<%= config.bin %> <%= command.id %> my-extension --enable --bundle my-bundle',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    bundle: Flags.string({
+      description: 'Bundle name if the extension belongs to a bundle',
+      helpValue: '<bundle>',
+    }),
+    disable: Flags.boolean({
+      description: 'Disable the extension',
+      exclusive: ['enable'],
+    }),
+    enable: Flags.boolean({
+      description: 'Enable the extension',
+      exclusive: ['disable'],
+    }),
+  };
+  static override summary = 'Enable or disable an extension';
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(ExtensionsToggle);
+
+    if (!flags.enable && !flags.disable) {
+      this.error('You must specify either --enable or --disable');
+    }
+
+    const enabled = Boolean(flags.enable);
+    const bundle = flags.bundle ?? null;
+
+    const sdkCommand = updateExtension(bundle, args.name, {
+      meta: {enabled},
+    }) as unknown as SdkRestCommand<unknown>;
+
+    const result = await this.client.request(sdkCommand);
+    this.outputFormatted(result);
+  }
+}

--- a/src/flags/global.ts
+++ b/src/flags/global.ts
@@ -21,7 +21,7 @@ export const globalFlags = {
   quiet: Flags.boolean({
     char: 'q',
     default: false,
-    description: 'Suppress non-data output (headers, footers, status messages)',
+    description: 'Suppress output metadata wrappers (counts, footers) and return data-only payload',
   }),
   token: Flags.string({
     char: 't',

--- a/src/flags/global.ts
+++ b/src/flags/global.ts
@@ -18,6 +18,11 @@ export const globalFlags = {
     env: 'DIRECTUS_PROFILE',
     helpValue: '<name>',
   }),
+  quiet: Flags.boolean({
+    char: 'q',
+    default: false,
+    description: 'Suppress non-data output (headers, footers, status messages)',
+  }),
   token: Flags.string({
     char: 't',
     description: 'Static access token (overrides profile)',

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -15,27 +15,30 @@ export function formatError(error: Error): string {
 
 /**
  * Format data for output based on the specified format.
+ * When quiet is true, suppresses metadata (counts, footers) and outputs only the data payload.
  */
 export function formatOutput(
   data: unknown,
   format: OutputFormat,
   meta?: {filterCount?: number; totalCount?: number},
+  quiet?: boolean,
 ): string {
+  const effectiveMeta = quiet ? undefined : meta;
   switch (format) {
   case 'json': {
-    return formatJson(data, meta);
+    return quiet ? JSON.stringify(data, null, 2) : formatJson(data, effectiveMeta);
   }
 
   case 'table': {
-    return formatTable(data, meta);
+    return formatTable(data, effectiveMeta);
   }
 
   case 'yaml': {
-    return formatYaml(data, meta);
+    return quiet ? YAML.stringify(data) : formatYaml(data, effectiveMeta);
   }
 
   default: {
-    return formatJson(data, meta);
+    return quiet ? JSON.stringify(data, null, 2) : formatJson(data, effectiveMeta);
   }
   }
 }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -30,6 +30,16 @@ export function formatOutput(
   }
 
   case 'table': {
+    if (quiet) {
+      if (!Array.isArray(data)) {
+        return JSON.stringify(data, null, 2);
+      }
+
+      if (data.length === 0) {
+        return '';
+      }
+    }
+
     return formatTable(data, effectiveMeta);
   }
 

--- a/test/lib/output.test.ts
+++ b/test/lib/output.test.ts
@@ -48,5 +48,49 @@ describe('output', () => {
       const result = formatOutput([], 'table', { totalCount: 0 });
       expect(result).toContain('No results');
     });
+
+    describe('quiet mode', () => {
+      it('outputs raw JSON without data wrapper when quiet', () => {
+        const result = formatOutput(data, 'json', { totalCount: 100 }, true);
+        const parsed = JSON.parse(result);
+        // Should be the raw data array, not wrapped in { data, meta }
+        expect(parsed).toEqual(data);
+      });
+
+      it('suppresses metadata in quiet JSON', () => {
+        const result = formatOutput(data, 'json', { totalCount: 100 }, true);
+        const parsed = JSON.parse(result);
+        expect(parsed).not.toHaveProperty('meta');
+        expect(parsed).not.toHaveProperty('data');
+      });
+
+      it('outputs raw YAML without data wrapper when quiet', () => {
+        const result = formatOutput(data, 'yaml', { totalCount: 100 }, true);
+        expect(result).not.toContain('data:');
+        expect(result).not.toContain('meta:');
+        expect(result).toContain('title: First Post');
+      });
+
+      it('returns empty string for empty array in quiet table mode', () => {
+        const result = formatOutput([], 'table', { totalCount: 0 }, true);
+        expect(result).toBe('');
+      });
+
+      it('returns raw JSON for non-array data in quiet table mode', () => {
+        const singleItem = { id: 1, name: 'Test' };
+        const result = formatOutput(singleItem, 'table', undefined, true);
+        const parsed = JSON.parse(result);
+        // Should be the raw object, not wrapped in { data }
+        expect(parsed).toEqual(singleItem);
+      });
+
+      it('renders table without metadata footer when quiet', () => {
+        const result = formatOutput(data, 'table', { totalCount: 100 }, true);
+        // Table should still render data rows
+        expect(result).toContain('First Post');
+        // But should not have the "Total: X items" footer
+        expect(result).not.toContain('Total:');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Extensions commands**: New `extensions list` command with `--type` and `--enabled` filters, and `extensions toggle` command with `--enable`/`--disable`/`--bundle` flags.
- **--quiet flag**: New global `-q`/`--quiet` flag that suppresses metadata wrappers (headers, footers, counts) in output, emitting only the data payload. Works across all output formats (json, yaml, table).
- **Collections --names-only**: New `--names-only` flag on `collections list` that returns a flat array of collection names instead of full collection objects.
- **Lint fixes**: Applied eslint formatting for `eslint-config-oclif` stylistic rules on all touched files.

## Semantic Release

This PR uses the `feat:` prefix and will trigger a **minor** version bump (e.g. 0.1.x → 0.2.0) when merged to `main`.

## Note on merge order

This PR and #2 (fix) both modify `src/base-command.ts` in different, non-overlapping sections. Whichever merges second should auto-merge cleanly since the changes are in different methods (`finally()` vs `outputFormatted()`).

## Files Changed

| File | Change |
|------|--------|
| `src/commands/extensions/list.ts` | New command |
| `src/commands/extensions/toggle.ts` | New command |
| `src/commands/collections/list.ts` | `--names-only` flag, full objects by default |
| `src/flags/global.ts` | `--quiet` flag |
| `src/lib/output.ts` | Quiet parameter support |
| `src/base-command.ts` | Wire quiet flag to `outputFormatted` |
| `package.json` | Register extensions oclif topic |