### PR TITLE
ci: remove @semantic-release/git plugin to fix release workflow

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,13 +5,6 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Problem
The release workflow fails because `@semantic-release/git` attempts to push commits (CHANGELOG.md, package.json version bump) directly to the protected `main` branch. Branch protection rules reject this:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Solution
Remove the `@semantic-release/git` plugin. This allows semantic-release to:
- Determine the next version from git tags (not package.json)
- Publish to npm (version written to package.json at build time, discarded after)
- Create GitHub Release with release notes
- Create git tags via GitHub API (bypasses branch protection)

## Trade-off
CHANGELOG.md won't be committed back to `main`. Release notes remain available via GitHub Releases. This is the official recommendation from semantic-release maintainers for repos with strict branch protection.

**Refs:** https://github.com/semantic-release/semantic-release/discussions/2557

---

After this PR merges, I will create a `v0.0.0` tag on main to anchor versioning at 0.x, preventing the historical `BREAKING CHANGE:` footer from triggering a 1.0.0 release.