### PR TITLE
ci: reduce npm noise during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Reduce npm noise during publish
+          NPM_CONFIG_FUND: false
+          NPM_CONFIG_AUDIT: false
         run: pnpm exec semantic-release


### PR DESCRIPTION
## Summary
Adds npm configuration to reduce notice output during publish.

## Context
Previous release (v0.1.0) failed because:
1. npm publish succeeded but E403 error occurred (version already existed from partial run)
2. semantic-release treated this as failure
3. GitHub Release was never created (had to be manually added)

## Changes
- Set `NPM_CONFIG_FUND=false` and `NPM_CONFIG_AUDIT=false` to reduce npm notice spam

## Future edge case handling
If this happens again (version exists on npm but no GitHub Release), run:
```bash
gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes"
```