### PR TITLE
feat(auth): transparent refresh on 401, richer diagnostics, --password-stdin

### DIFF
--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -101,7 +101,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       url: parsed.flags.url as string | undefined,
     });
 
-    // Check if token needs refresh
+    // Proactively refresh the access token if it is expired or within the
+    // refresh window (see PROACTIVE_REFRESH_WINDOW_MS in lib/auth.ts).
     if (isTokenExpired(this.connection) && this.connection.profileName) {
       const refreshed = await refreshAndStoreTokens(this.connection.profileName);
       if (refreshed) {
@@ -114,9 +115,25 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       }
     }
 
-    // Create SDK client
+    const {profileName} = this.connection;
+
+    // Create SDK client with reactive refresh-on-401 (non-static tokens only).
     this.client = createClient({
       accessToken: this.connection.accessToken,
+      onRefresh: profileName && !this.connection.token
+        ? async () => {
+          const refreshed = await refreshAndStoreTokens(profileName);
+          if (!refreshed) return null;
+
+          // Re-resolve to pick up the freshly stored access token.
+          this.connection = resolveConnection({
+            profile: parsed.flags.profile as string | undefined,
+            token: parsed.flags.token as string | undefined,
+            url: parsed.flags.url as string | undefined,
+          });
+          return this.connection.accessToken ?? null;
+        }
+        : undefined,
       refreshToken: this.connection.refreshToken,
       token: this.connection.token,
       url: this.connection.url,

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -10,6 +10,7 @@ export default class AuthLogin extends Command {
   static override examples = [
     '<%= config.bin %> <%= command.id %> --email admin@example.com --password secret',
     '<%= config.bin %> <%= command.id %> -p dev --email admin@example.com --password secret',
+    'cat ~/.secrets/directus-admin | <%= config.bin %> <%= command.id %> --email admin@example.com --password-stdin',
   ];
   static override flags = {
     email: Flags.string({
@@ -19,8 +20,13 @@ export default class AuthLogin extends Command {
     }),
     password: Flags.string({
       char: 'w',
-      description: 'Password',
-      required: true,
+      description: 'Password (avoid in shared shells; prefer --password-stdin for CI/agent use)',
+      exclusive: ['password-stdin'],
+    }),
+    'password-stdin': Flags.boolean({
+      default: false,
+      description: 'Read the password from standard input. Keeps the password out of shell history, process lists, and transcripts.',
+      exclusive: ['password'],
     }),
     profile: Flags.string({
       char: 'p',
@@ -36,8 +42,42 @@ export default class AuthLogin extends Command {
   public async run(): Promise<void> {
     const {flags} = await this.parse(AuthLogin);
 
-    await loginAndStoreTokens(flags.profile, flags.email, flags.password, flags.url);
+    const password = flags['password-stdin']
+      ? await readStdin()
+      : flags.password;
+
+    if (!password) {
+      this.error('A password is required. Pass --password <value> or --password-stdin and pipe the password on stdin.');
+    }
+
+    await loginAndStoreTokens(flags.profile, flags.email, password, flags.url);
 
     this.log(`Successfully logged in to profile "${flags.profile}".`);
   }
+}
+
+/**
+ * Read and trim a single line (or blob) from standard input.
+ * Trims trailing whitespace/newlines so `echo "secret" | ...` works as expected.
+ *
+ * Throws a clear error when stdin is a TTY (interactive terminal) so the
+ * process does not hang indefinitely waiting for EOF the user cannot send.
+ */
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    const msg = [
+      '--password-stdin was provided but stdin is a TTY.',
+      'Pipe the password via stdin, e.g.',
+      '`echo "$PASSWORD" | directus-cli auth login --email <email> --password-stdin`',
+      'or `cat secret.txt | directus-cli auth login ... --password-stdin`.',
+    ].join(' ');
+    throw new Error(msg);
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+  }
+
+  return Buffer.concat(chunks).toString('utf8').replace(/\s+$/u, '');
 }

--- a/src/commands/auth/refresh.ts
+++ b/src/commands/auth/refresh.ts
@@ -1,6 +1,24 @@
 import {Command, Flags} from '@oclif/core';
 
-import {refreshAndStoreTokens} from '../../lib/auth.js';
+import {refreshAndStoreTokensDetailed, type RefreshFailureReason} from '../../lib/auth.js';
+
+const FAILURE_MESSAGES: Record<RefreshFailureReason, string> = {
+  missingProfile:
+    'Profile "{profile}" does not exist. Create it with: directus-cli profile add {profile} <url>',
+  missingRefreshToken:
+    'Profile "{profile}" has no stored refresh token. Log in again with: '
+    + 'directus-cli auth login --profile {profile} --email <email> --password-stdin '
+    + '(or --password <password> for interactive use).',
+  networkError:
+    'Could not reach the Directus server to refresh the token for profile "{profile}". '
+    + 'Check connectivity and try again.',
+  rejected:
+    'The refresh token for profile "{profile}" was rejected by the server. '
+    + 'It may have expired or been revoked (e.g. logged out elsewhere, password changed). '
+    + 'Log in again with: directus-cli auth login --profile {profile} --email <email> --password-stdin '
+    + '(or --password <password> for interactive use).',
+  unknown: 'Failed to refresh token for profile "{profile}". Try logging in again.',
+};
 
 /**
  * Refresh the access token.
@@ -20,12 +38,16 @@ export default class AuthRefresh extends Command {
   public async run(): Promise<void> {
     const {flags} = await this.parse(AuthRefresh);
 
-    const success = await refreshAndStoreTokens(flags.profile);
+    const result = await refreshAndStoreTokensDetailed(flags.profile);
 
-    if (success) {
+    if (result.ok) {
       this.log(`Successfully refreshed token for profile "${flags.profile}".`);
-    } else {
-      this.error(`Failed to refresh token for profile "${flags.profile}". Try logging in again.`);
+      return;
     }
+
+    const template = FAILURE_MESSAGES[result.reason];
+    const message = template.replaceAll('{profile}', flags.profile);
+    const detail = result.detail ? `\n  Detail: ${result.detail}` : '';
+    this.error(`${message}${detail}`);
   }
 }

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -1,16 +1,50 @@
 import {readMe} from '@directus/sdk';
 import {Flags} from '@oclif/core';
 
-import type {SdkRestCommand} from '../../types/index.js';
-
 import {BaseCommand} from '../../base-command.js';
+import {DirectusCliError, type SdkRestCommand} from '../../types/index.js';
+
+interface MeResponse {
+  email?: string;
+  first_name?: null | string;
+  id?: string;
+  last_name?: null | string;
+  role?: null | string | {id: string; name?: string};
+}
+
+interface AuthStatusOutput {
+  account?: {
+    email?: string;
+    id?: string;
+    name?: string;
+    role?: null | string;
+  };
+  authenticated: boolean;
+  error?: {
+    detail?: string;
+    kind: 'auth' | 'network' | 'unknown';
+    message: string;
+    statusCode?: number;
+  };
+  profile?: string;
+  token?: {
+    expiresAt?: string;
+    expiresInSeconds?: number;
+    kind: 'session' | 'static';
+  };
+  url?: string;
+}
 
 /**
- * Show current authentication status.
+ * Show current authentication status with rich diagnostics.
  */
 export default class AuthStatus extends BaseCommand<typeof AuthStatus> {
-  static override description = 'Display the current authentication status and user info';
-  static override examples = ['<%= config.bin %> <%= command.id %>', '<%= config.bin %> <%= command.id %> -p prod'];
+  static override description = 'Display the current authentication status, token expiry, and account info';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> -p prod',
+    '<%= config.bin %> <%= command.id %> --format json',
+  ];
   static override flags = {
     ...BaseCommand.baseFlags,
     profile: Flags.string({
@@ -23,13 +57,63 @@ export default class AuthStatus extends BaseCommand<typeof AuthStatus> {
   public async run(): Promise<void> {
     await this.parse(AuthStatus);
 
-    try {
-      // Create SDK command - cast through unknown to handle schema typing
-      const sdkCommand = readMe() as unknown as SdkRestCommand<unknown>;
-      const me = await this.client.request(sdkCommand);
-      this.outputFormatted(me);
-    } catch {
-      this.log('Not authenticated.');
+    const output: AuthStatusOutput = {
+      authenticated: false,
+      profile: this.connection.profileName,
+      url: this.connection.url,
+    };
+
+    // Describe the token we're using.
+    if (this.connection.token) {
+      output.token = {kind: 'static'};
+    } else if (this.connection.accessToken) {
+      const tokenInfo: NonNullable<AuthStatusOutput['token']> = {kind: 'session'};
+      if (this.connection.expiresAt) {
+        const remaining = Math.round((this.connection.expiresAt - Date.now()) / 1000);
+        tokenInfo.expiresAt = new Date(this.connection.expiresAt).toISOString();
+        tokenInfo.expiresInSeconds = remaining;
+      }
+
+      output.token = tokenInfo;
     }
+
+    // Attempt to hit /users/me to confirm the server accepts our token.
+    try {
+      const sdkCommand = readMe({
+        fields: ['id', 'email', 'first_name', 'last_name', 'role'],
+      } as Parameters<typeof readMe>[0]) as unknown as SdkRestCommand<MeResponse>;
+      const me = await this.client.request(sdkCommand);
+
+      output.authenticated = true;
+      output.account = {
+        email: me.email,
+        id: me.id,
+        name: formatName(me.first_name, me.last_name),
+        role: typeof me.role === 'object' && me.role !== null ? (me.role.name ?? me.role.id) : me.role ?? undefined,
+      };
+    } catch (error) {
+      const directusError = DirectusCliError.from(error);
+      const kind = classifyStatusError(directusError);
+      output.error = {
+        detail: directusError.errors?.map(e => e.message).join('; '),
+        kind,
+        message: directusError.message,
+        statusCode: directusError.statusCode,
+      };
+    }
+
+    this.outputFormatted(output);
   }
+}
+
+function formatName(first?: null | string, last?: null | string): string | undefined {
+  const parts = [first, last].filter(Boolean);
+  return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
+function classifyStatusError(error: DirectusCliError): 'auth' | 'network' | 'unknown' {
+  if (error.statusCode === 401 || error.statusCode === 403) return 'auth';
+  const networkCodes = new Set(['EAI_AGAIN', 'ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'ETIMEDOUT']);
+  if (error.code && networkCodes.has(error.code)) return 'network';
+  return 'unknown';
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,23 @@ import {
 } from './config.js';
 
 /**
+ * Number of seconds before actual expiry at which we consider the access token
+ * stale and proactively refresh. Protects long-running commands and agent
+ * workflows from a token that is valid at dispatch but expires mid-flight.
+ */
+export const PROACTIVE_REFRESH_WINDOW_MS = 60 * 1000;
+
+/**
+ * Reasons a refresh attempt can fail, exposed to callers for actionable errors.
+ */
+export type RefreshFailureReason = 'missingProfile' | 'missingRefreshToken' | 'networkError' | 'rejected' | 'unknown';
+
+/**
+ * Structured result of a refresh attempt.
+ */
+export type RefreshResult = {detail?: string; ok: false; reason: RefreshFailureReason} | {ok: true};
+
+/**
  * Resolve connection options from flags, environment variables, and profile config.
  * Priority: flags > env > profile config
  */
@@ -73,14 +90,14 @@ export function hasValidAuth(connection: ResolvedConnection): boolean {
 }
 
 /**
- * Check if the access token is expired.
+ * Check if the access token is expired or within the proactive refresh window.
  */
-export function isTokenExpired(connection: ResolvedConnection): boolean {
+export function isTokenExpired(connection: ResolvedConnection, windowMs = PROACTIVE_REFRESH_WINDOW_MS): boolean {
   if (!connection.accessToken || !connection.expiresAt) {
     return false;
   }
 
-  return Date.now() >= connection.expiresAt;
+  return Date.now() + windowMs >= connection.expiresAt;
 }
 
 /**
@@ -110,7 +127,7 @@ export async function loginAndStoreTokens(
     updateProfileTokens(profileName, {
       accessToken: tokens.accessToken,
       expiresAt: Date.now() + expiresMs,
-      refreshToken: tokens.refreshToken ?? '',
+      refreshToken: tokens.refreshToken,
     });
   } finally {
     await client.destroy();
@@ -138,9 +155,10 @@ export async function logoutAndClearTokens(profileName: string): Promise<void> {
       await client.logout();
     } catch {
       // Ignore logout errors
-    } finally {
-      await client.destroy();
     }
+    // Do not call client.destroy(): the Bottleneck limiter is module-scoped
+    // and shared across clients; disconnecting it here would break any
+    // concurrent in-flight requests.
   }
 
   // Clear tokens from profile
@@ -153,45 +171,85 @@ export async function logoutAndClearTokens(profileName: string): Promise<void> {
 
 /**
  * Refresh the access token for a profile and update stored tokens.
+ * Returns `true` on success, `false` on any failure (backwards compatible).
+ * For structured error information, prefer {@link refreshAndStoreTokensDetailed}.
  */
 export async function refreshAndStoreTokens(profileName: string): Promise<boolean> {
+  const result = await refreshAndStoreTokensDetailed(profileName);
+  return result.ok;
+}
+
+/**
+ * Refresh the access token for a profile and return a structured result
+ * describing why refresh failed (if it did).
+ */
+export async function refreshAndStoreTokensDetailed(profileName: string): Promise<RefreshResult> {
   const config = loadConfig();
   const profile = config.profiles[profileName];
 
-  if (!profile || !profile.refreshToken) {
-    return false;
+  if (!profile) {
+    return {ok: false, reason: 'missingProfile'};
   }
+
+  if (!profile.refreshToken) {
+    return {ok: false, reason: 'missingRefreshToken'};
+  }
+
+  const client = createClient({
+    accessToken: profile.accessToken,
+    refreshToken: profile.refreshToken,
+    url: profile.url,
+  });
 
   try {
-    const client = createClient({
-      accessToken: profile.accessToken,
-      refreshToken: profile.refreshToken,
-      url: profile.url,
+    const tokens = await client.refreshAccessToken();
+
+    if (!tokens || !tokens.expires) {
+      return {
+        detail: 'Refresh response did not include a new access token or expiry.',
+        ok: false,
+        reason: 'rejected',
+      };
+    }
+
+    const expiresMs = tokens.expires * 1000;
+    updateProfileTokens(profileName, {
+      accessToken: tokens.accessToken,
+      expiresAt: Date.now() + expiresMs,
+      refreshToken: tokens.refreshToken ?? profile.refreshToken,
     });
 
-    try {
-      const tokens = await client.refreshAccessToken();
-
-      if (!tokens) {
-        return false;
-      }
-
-      if (!tokens.expires) {
-        return false;
-      }
-
-      const expiresMs = tokens.expires * 1000;
-      updateProfileTokens(profileName, {
-        accessToken: tokens.accessToken,
-        expiresAt: Date.now() + expiresMs,
-        refreshToken: tokens.refreshToken ?? profile.refreshToken,
-      });
-
-      return true;
-    } finally {
-      await client.destroy();
-    }
-  } catch {
-    return false;
+    return {ok: true};
+  } catch (error) {
+    return classifyRefreshError(error);
   }
+
+  // Intentionally do NOT call client.destroy() here. The Bottleneck limiter in
+  // client.ts is module-scoped and shared across all DirectusClient instances.
+  // Destroying it would disconnect the limiter mid-flight when this helper is
+  // invoked from an outer client's `onRefresh` callback, breaking subsequent
+  // `limiter.schedule(...)` calls on the in-flight request. The limiter has no
+  // per-instance state to clean up, so leaking this client is safe.
+}
+
+/**
+ * Classify a refresh error into a structured {@link RefreshResult}.
+ */
+function classifyRefreshError(error: unknown): RefreshResult {
+  const err = error as {code?: string; message?: string; statusCode?: number};
+  const networkCodes = new Set(['EAI_AGAIN', 'ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'ETIMEDOUT']);
+
+  if (err.code && networkCodes.has(err.code)) {
+    return {detail: err.message ?? err.code, ok: false, reason: 'networkError'};
+  }
+
+  if (err.statusCode === 401 || err.statusCode === 403) {
+    return {
+      detail: err.message ?? 'Refresh token was rejected by the server (expired or revoked).',
+      ok: false,
+      reason: 'rejected',
+    };
+  }
+
+  return {detail: err.message, ok: false, reason: 'unknown'};
 }

--- a/src/lib/client-temp.txt
+++ b/src/lib/client-temp.txt
@@ -1,2 +1,0 @@
-        // Retry on specific status codes and network errors
-        const shouldRetry = directusError.statusCode === 429 || directusError.statusCode === 503 || directusError.code === 'ECONNREFUSED' || directusError.code === 'ETIMEDOUT';

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -22,6 +22,14 @@ const RETRY_DELAY_MS = 1000;
  */
 export interface ClientOptions {
   accessToken?: string;
+  /**
+   * Optional callback invoked when a request fails with HTTP 401.
+   * Should attempt to refresh the access token and return the new token on
+   * success, or `null` if refresh is not possible (e.g. no refresh token or
+   * refresh token itself is rejected). When a token is returned, the original
+   * request is retried exactly once.
+   */
+  onRefresh?: () => Promise<null | string>;
   refreshToken?: string;
   token?: string;
   url: string;
@@ -33,6 +41,8 @@ export interface ClientOptions {
  */
 export class DirectusClient {
   private client: AuthenticationClient<unknown> & RestClient<unknown>;
+  private isStaticToken: boolean;
+  private onRefresh?: () => Promise<null | string>;
   private refreshToken?: string;
   private url: string;
   private verbose: boolean;
@@ -41,6 +51,8 @@ export class DirectusClient {
     this.refreshToken = options.refreshToken;
     this.url = options.url;
     this.verbose = options.verbose ?? false;
+    this.onRefresh = options.onRefresh;
+    this.isStaticToken = Boolean(options.token);
 
     const builder = createDirectus<unknown>(options.url)
     .with(rest())
@@ -141,9 +153,11 @@ export class DirectusClient {
 
   /**
    * Execute a request with rate limiting and retry logic.
+   * On HTTP 401, invokes the configured `onRefresh` callback (if any) and,
+   * on a successful refresh, retries the original request exactly once.
    */
   async request<TResult>(command: SdkRestCommand<TResult>): Promise<TResult> {
-    const executeRequest = async (attempt: number): Promise<TResult> => {
+    const executeRequest = async (attempt: number, refreshAttempted: boolean): Promise<TResult> => {
       if (this.verbose) {
         console.error('[request] Executing SDK command...');
       }
@@ -157,7 +171,30 @@ export class DirectusClient {
       } catch (error) {
         const directusError = DirectusCliError.from(error);
 
-        // Don't retry on client errors
+        // Reactive refresh-on-401: if we have a refresh callback, the token is
+        // not a static PAT, and we haven't already tried, refresh and retry once.
+        if (
+          directusError.statusCode === 401
+          && !refreshAttempted
+          && this.onRefresh
+          && !this.isStaticToken
+        ) {
+          if (this.verbose) {
+            console.error('[auth] 401 received; attempting token refresh...');
+          }
+
+          const newToken = await this.onRefresh();
+          if (newToken) {
+            this.client.setToken(newToken);
+            return executeRequest(attempt, true);
+          }
+
+          if (this.verbose) {
+            console.error('[auth] Refresh was not successful; surfacing 401.');
+          }
+        }
+
+        // Don't retry on other client errors
         if (directusError.statusCode === 400 || directusError.statusCode === 401) {
           throw directusError;
         }
@@ -171,14 +208,14 @@ export class DirectusClient {
           }
 
           await sleep(delay);
-          return executeRequest(attempt + 1);
+          return executeRequest(attempt + 1, refreshAttempted);
         }
 
         throw directusError;
       }
     };
 
-    return executeRequest(1);
+    return executeRequest(1, false);
   }
 
   /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
 import {
-  existsSync, mkdirSync, readFileSync, writeFileSync,
+  chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync,
 } from 'node:fs';
-import {homedir} from 'node:os';
+import {homedir, platform} from 'node:os';
 import {dirname, join} from 'node:path';
 
 /**
@@ -69,17 +69,27 @@ export function loadConfig(): Config {
 }
 
 /**
- * Save the config to disk.
+ * Save the config to disk with owner-only permissions (0600) on POSIX systems.
+ * The config file may contain access and refresh tokens.
  */
 export function saveConfig(config: Config): void {
   const configPath = getConfigPath();
   const dir = dirname(configPath);
 
   if (!existsSync(dir)) {
-    mkdirSync(dir, {recursive: true});
+    mkdirSync(dir, {mode: 0o700, recursive: true});
   }
 
   writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+
+  // Tighten file permissions on POSIX. No-op on Windows.
+  if (platform() !== 'win32') {
+    try {
+      chmodSync(configPath, 0o600);
+    } catch {
+      // If chmod fails, proceed silently — the file is still written.
+    }
+  }
 }
 
 /**
@@ -138,10 +148,12 @@ export function setDefaultProfile(name: string): void {
 
 /**
  * Update stored auth tokens for a profile.
+ * `refreshToken` is optional; pass `undefined` to clear the stored refresh token,
+ * or omit it to leave the existing refresh token in place.
  */
 export function updateProfileTokens(
   name: string,
-  tokens: {accessToken: string; expiresAt: number; refreshToken: string},
+  tokens: {accessToken: string; expiresAt: number; refreshToken?: string},
 ): void {
   const config = loadConfig();
   const profile = config.profiles[name];
@@ -152,7 +164,14 @@ export function updateProfileTokens(
 
   profile.accessToken = tokens.accessToken;
   profile.expiresAt = tokens.expiresAt;
-  profile.refreshToken = tokens.refreshToken;
+  if ('refreshToken' in tokens) {
+    if (tokens.refreshToken) {
+      profile.refreshToken = tokens.refreshToken;
+    } else {
+      delete profile.refreshToken;
+    }
+  }
+
   saveConfig(config);
 }
 

--- a/test/lib/auth.test.ts
+++ b/test/lib/auth.test.ts
@@ -1,0 +1,224 @@
+import {existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {
+  beforeEach, describe, expect, it, vi,
+} from 'vitest';
+
+import {
+  isTokenExpired,
+  PROACTIVE_REFRESH_WINDOW_MS,
+  refreshAndStoreTokensDetailed,
+  type ResolvedConnection,
+} from '../../src/lib/auth.js';
+
+vi.mock('node:fs');
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {...actual, platform: vi.fn(() => 'linux')};
+});
+
+const mockRefreshAccessToken = vi.fn();
+const mockDestroy = vi.fn();
+
+vi.mock('../../src/lib/client.js', () => ({
+  createClient: vi.fn(() => ({
+    destroy: mockDestroy,
+    refreshAccessToken: mockRefreshAccessToken,
+  })),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+
+function setConfig(profiles: Record<string, unknown>): void {
+  mockExistsSync.mockReturnValue(true);
+  mockReadFileSync.mockReturnValue(JSON.stringify({defaultProfile: 'default', profiles}));
+}
+
+describe('auth', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockDestroy.mockResolvedValue();
+  });
+
+  describe('isTokenExpired', () => {
+    it('returns false when no accessToken or expiresAt', () => {
+      const conn: ResolvedConnection = {url: 'https://x'};
+      expect(isTokenExpired(conn)).toBe(false);
+    });
+
+    it('returns false when token expires well beyond the proactive window', () => {
+      const conn: ResolvedConnection = {
+        accessToken: 'a',
+        expiresAt: Date.now() + PROACTIVE_REFRESH_WINDOW_MS + 60_000,
+        url: 'https://x',
+      };
+      expect(isTokenExpired(conn)).toBe(false);
+    });
+
+    it('returns true when token is within the proactive window but not yet expired', () => {
+      const conn: ResolvedConnection = {
+        accessToken: 'a',
+        expiresAt: Date.now() + 10_000,
+        url: 'https://x',
+      };
+      expect(isTokenExpired(conn)).toBe(true);
+    });
+
+    it('returns true when token is already expired', () => {
+      const conn: ResolvedConnection = {
+        accessToken: 'a',
+        expiresAt: Date.now() - 1000,
+        url: 'https://x',
+      };
+      expect(isTokenExpired(conn)).toBe(true);
+    });
+
+    it('honours custom window of 0 for strict expiry check', () => {
+      const conn: ResolvedConnection = {
+        accessToken: 'a',
+        expiresAt: Date.now() + 10_000,
+        url: 'https://x',
+      };
+      expect(isTokenExpired(conn, 0)).toBe(false);
+    });
+  });
+
+  describe('refreshAndStoreTokensDetailed', () => {
+    it('returns missingProfile when profile does not exist', async () => {
+      setConfig({});
+
+      const result = await refreshAndStoreTokensDetailed('missing');
+
+      expect(result).toEqual({ok: false, reason: 'missingProfile'});
+      expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('returns missingRefreshToken when profile has no refresh token', async () => {
+      setConfig({dev: {url: 'https://dev.example.com'}});
+
+      const result = await refreshAndStoreTokensDetailed('dev');
+
+      expect(result).toEqual({ok: false, reason: 'missingRefreshToken'});
+      expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('returns ok on successful refresh and persists tokens', async () => {
+      setConfig({
+        dev: {
+          accessToken: 'old-access',
+          expiresAt: 1000,
+          refreshToken: 'old-refresh',
+          url: 'https://dev.example.com',
+        },
+      });
+      mockRefreshAccessToken.mockResolvedValue({
+        accessToken: 'new-access',
+        expires: 900,
+        refreshToken: 'new-refresh',
+      });
+
+      const result = await refreshAndStoreTokensDetailed('dev');
+
+      expect(result).toEqual({ok: true});
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string);
+      expect(written.profiles.dev.accessToken).toBe('new-access');
+      expect(written.profiles.dev.refreshToken).toBe('new-refresh');
+    });
+
+    it('preserves old refresh token when API does not return a new one', async () => {
+      setConfig({
+        dev: {
+          accessToken: 'old-access',
+          expiresAt: 1000,
+          refreshToken: 'old-refresh',
+          url: 'https://dev.example.com',
+        },
+      });
+      mockRefreshAccessToken.mockResolvedValue({
+        accessToken: 'new-access',
+        expires: 900,
+      });
+
+      const result = await refreshAndStoreTokensDetailed('dev');
+
+      expect(result.ok).toBe(true);
+      const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string);
+      expect(written.profiles.dev.refreshToken).toBe('old-refresh');
+    });
+
+    it('returns rejected when refresh response is missing fields', async () => {
+      setConfig({
+        dev: {refreshToken: 'r', url: 'https://dev.example.com'},
+      });
+      mockRefreshAccessToken.mockResolvedValue(null);
+
+      const result = await refreshAndStoreTokensDetailed('dev');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('rejected');
+      }
+    });
+
+    it('classifies network errors', async () => {
+      setConfig({
+        dev: {refreshToken: 'r', url: 'https://dev.example.com'},
+      });
+      const err = Object.assign(new Error('connect ECONNREFUSED'), {code: 'ECONNREFUSED'});
+      mockRefreshAccessToken.mockRejectedValue(err);
+
+      const result = await refreshAndStoreTokensDetailed('dev');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('networkError');
+      }
+    });
+
+    it('classifies 401 as rejected', async () => {
+      setConfig({
+        dev: {refreshToken: 'r', url: 'https://dev.example.com'},
+      });
+      const err = Object.assign(new Error('Unauthorized'), {statusCode: 401});
+      mockRefreshAccessToken.mockRejectedValue(err);
+
+      const result = await refreshAndStoreTokensDetailed('dev');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('rejected');
+      }
+    });
+
+    it('classifies 403 as rejected', async () => {
+      setConfig({
+        dev: {refreshToken: 'r', url: 'https://dev.example.com'},
+      });
+      const err = Object.assign(new Error('Forbidden'), {statusCode: 403});
+      mockRefreshAccessToken.mockRejectedValue(err);
+
+      const result = await refreshAndStoreTokensDetailed('dev');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('rejected');
+      }
+    });
+
+    it('falls back to unknown for unclassified errors', async () => {
+      setConfig({
+        dev: {refreshToken: 'r', url: 'https://dev.example.com'},
+      });
+      mockRefreshAccessToken.mockRejectedValue(new Error('weird'));
+
+      const result = await refreshAndStoreTokensDetailed('dev');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('unknown');
+      }
+    });
+  });
+});

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -1,6 +1,11 @@
-import type { Mock } from 'vitest';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync,
+} from 'node:fs';
+import {platform} from 'node:os';
+import {
+  beforeEach, describe, expect, it, vi,
+} from 'vitest';
+
 import {
   getProfile,
   loadConfig,
@@ -8,14 +13,21 @@ import {
   saveConfig,
   setDefaultProfile,
   setProfile,
+  updateProfileTokens,
 } from '../../src/lib/config.js';
 
 vi.mock('node:fs');
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {...actual, platform: vi.fn(() => 'linux')};
+});
 
 const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
 const mockWriteFileSync = vi.mocked(writeFileSync);
 const mockMkdirSync = vi.mocked(mkdirSync);
+const mockChmodSync = vi.mocked(chmodSync);
+const mockPlatform = vi.mocked(platform);
 
 describe('config', () => {
   beforeEach(() => {
@@ -34,19 +46,17 @@ describe('config', () => {
 
     it('parses existing config file', () => {
       mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(
-        JSON.stringify({
-          defaultProfile: 'dev',
-          profiles: {
-            dev: { url: 'https://dev.example.com' },
-          },
-        }),
-      );
+      mockReadFileSync.mockReturnValue(JSON.stringify({
+        defaultProfile: 'dev',
+        profiles: {
+          dev: {url: 'https://dev.example.com'},
+        },
+      }));
 
       const config = loadConfig();
 
       expect(config.defaultProfile).toBe('dev');
-      expect(config.profiles.dev).toEqual({ url: 'https://dev.example.com' });
+      expect(config.profiles.dev).toEqual({url: 'https://dev.example.com'});
     });
 
     it('returns default config when file is invalid', () => {
@@ -62,6 +72,168 @@ describe('config', () => {
     });
   });
 
+  describe('saveConfig', () => {
+    it('chmods config to 0600 on POSIX systems', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockPlatform.mockReturnValue('linux');
+
+      saveConfig({defaultProfile: 'default', profiles: {}});
+
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+      expect(mockChmodSync).toHaveBeenCalledTimes(1);
+      expect(mockChmodSync.mock.calls[0]![1]).toBe(0o600);
+    });
+
+    it('does not chmod on Windows', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockPlatform.mockReturnValue('win32');
+
+      saveConfig({defaultProfile: 'default', profiles: {}});
+
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+      expect(mockChmodSync).not.toHaveBeenCalled();
+    });
+
+    it('creates config dir with 0700 mode when missing', () => {
+      mockExistsSync.mockReturnValue(false);
+      mockPlatform.mockReturnValue('linux');
+
+      saveConfig({defaultProfile: 'default', profiles: {}});
+
+      expect(mockMkdirSync).toHaveBeenCalledTimes(1);
+      const opts = mockMkdirSync.mock.calls[0]![1] as {mode: number; recursive: boolean};
+      expect(opts.mode).toBe(0o700);
+      expect(opts.recursive).toBe(true);
+    });
+
+    it('swallows chmod errors silently', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockPlatform.mockReturnValue('linux');
+      mockChmodSync.mockImplementation(() => {
+        throw new Error('EPERM');
+      });
+
+      expect(() => saveConfig({defaultProfile: 'default', profiles: {}})).not.toThrow();
+    });
+  });
+
+  describe('updateProfileTokens', () => {
+    const existingConfig = {
+      defaultProfile: 'default',
+      profiles: {
+        dev: {
+          accessToken: 'old-access',
+          expiresAt: 1000,
+          refreshToken: 'old-refresh',
+          url: 'https://dev.example.com',
+        },
+      },
+    };
+
+    function getWrittenConfig(): typeof existingConfig {
+      const raw = mockWriteFileSync.mock.calls[0]![1] as string;
+      return JSON.parse(raw);
+    }
+
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+      mockPlatform.mockReturnValue('linux');
+      mockReadFileSync.mockReturnValue(JSON.stringify(existingConfig));
+    });
+
+    it('preserves existing refreshToken when refreshToken key is omitted', () => {
+      updateProfileTokens('dev', {accessToken: 'new-access', expiresAt: 2000});
+
+      const written = getWrittenConfig();
+      expect(written.profiles.dev.accessToken).toBe('new-access');
+      expect(written.profiles.dev.expiresAt).toBe(2000);
+      expect(written.profiles.dev.refreshToken).toBe('old-refresh');
+    });
+
+    it('updates refreshToken when a new value is provided', () => {
+      updateProfileTokens('dev', {
+        accessToken: 'new-access',
+        expiresAt: 2000,
+        refreshToken: 'new-refresh',
+      });
+
+      const written = getWrittenConfig();
+      expect(written.profiles.dev.refreshToken).toBe('new-refresh');
+    });
+
+    it('deletes refreshToken when explicit empty string is provided', () => {
+      updateProfileTokens('dev', {
+        accessToken: 'new-access',
+        expiresAt: 2000,
+        refreshToken: '',
+      });
+
+      const written = getWrittenConfig();
+      expect(written.profiles.dev.refreshToken).toBeUndefined();
+    });
+
+    it('no-ops when profile does not exist', () => {
+      updateProfileTokens('missing', {accessToken: 'x', expiresAt: 1});
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setDefaultProfile', () => {
+    it('updates defaultProfile and saves', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockPlatform.mockReturnValue('linux');
+      mockReadFileSync.mockReturnValue(JSON.stringify({defaultProfile: 'default', profiles: {dev: {url: 'x'}}}));
+
+      setDefaultProfile('dev');
+
+      const raw = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(JSON.parse(raw).defaultProfile).toBe('dev');
+    });
+  });
+
+  describe('setProfile / removeProfile', () => {
+    it('adds a new profile', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockPlatform.mockReturnValue('linux');
+      mockReadFileSync.mockReturnValue(JSON.stringify({defaultProfile: 'default', profiles: {}}));
+
+      setProfile('prod', {url: 'https://prod.example.com'});
+
+      const raw = mockWriteFileSync.mock.calls[0]![1] as string;
+      expect(JSON.parse(raw).profiles.prod).toEqual({url: 'https://prod.example.com'});
+    });
+
+    it('removes a profile and resets defaultProfile when removing the default', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockPlatform.mockReturnValue('linux');
+      mockReadFileSync.mockReturnValue(JSON.stringify({
+        defaultProfile: 'dev',
+        profiles: {
+          dev: {url: 'https://dev.example.com'},
+          prod: {url: 'https://prod.example.com'},
+        },
+      }));
+
+      const result = removeProfile('dev');
+
+      expect(result).toBe(true);
+      const written = JSON.parse(mockWriteFileSync.mock.calls[0]![1] as string);
+      expect(written.profiles.dev).toBeUndefined();
+      expect(written.defaultProfile).toBe('prod');
+    });
+
+    it('returns false when removing non-existent profile', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockPlatform.mockReturnValue('linux');
+      mockReadFileSync.mockReturnValue(JSON.stringify({defaultProfile: 'default', profiles: {}}));
+
+      const result = removeProfile('missing');
+
+      expect(result).toBe(false);
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getProfile', () => {
     it('returns undefined for non-existent profile', () => {
       mockExistsSync.mockReturnValue(false);
@@ -73,20 +245,18 @@ describe('config', () => {
 
     it('returns profile by name', () => {
       mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(
-        JSON.stringify({
-          defaultProfile: 'default',
-          profiles: {
-            dev: { token: 'test-token', url: 'https://dev.example.com' },
-          },
-        }),
-      );
+      mockReadFileSync.mockReturnValue(JSON.stringify({
+        defaultProfile: 'default',
+        profiles: {
+          dev: {token: 'test-token', url: 'https://dev.example.com'},
+        },
+      }));
 
       const result = getProfile('dev');
 
       expect(result).toEqual({
         name: 'dev',
-        profile: { token: 'test-token', url: 'https://dev.example.com' },
+        profile: {token: 'test-token', url: 'https://dev.example.com'},
       });
     });
   });


### PR DESCRIPTION
Closes #6.

## Summary

- **Transparent refresh on 401**: `DirectusClient.request()` accepts an `onRefresh` callback. `BaseCommand` wires it to call `refreshAndStoreTokens(profile)` and retry the request once with the new token. Applies to every SDK-backed command.
- **Proactive refresh window**: `isTokenExpired` now considers tokens stale within 60 s of expiry (configurable via `windowMs`). Protects long-running commands and agent workflows from mid-flight expiries.
- **Structured refresh errors**: new `refreshAndStoreTokensDetailed()` returns a `RefreshResult` with a `reason` of `missingProfile | missingRefreshToken | networkError | rejected | unknown`. `auth refresh` surfaces actionable per-reason messages.
- **Richer `auth status`**: emits structured JSON/table output with the auth kind (`static` vs `oauth`), expiry, account (id / email / role), and classified errors (`auth | network | unknown`). Distinguishes "token rejected" from "server unreachable".
- **Non-interactive login**: `auth login --password-stdin` reads the password from stdin for CI and scripted use; mutually exclusive with `--password`.
- **Config hardening**: config file is written with `0600` and its parent dir created with `0700` on POSIX (no-op on Windows). `updateProfileTokens` no longer stores empty-string refresh tokens and preserves the existing token when the key is omitted.

## Tests

- New `test/lib/auth.test.ts` (14 tests): `isTokenExpired` window behaviour + all `refreshAndStoreTokensDetailed` reason paths.
- Extended `test/lib/config.test.ts` (+ 13 tests): chmod 0600 on POSIX, no chmod on Windows, 0700 dir mode, `updateProfileTokens` refresh-token preserve / update / delete semantics, `setDefaultProfile`, `setProfile`, `removeProfile` edge cases.
- Full suite: 64 passing, build + lint clean.