### PR TITLE
feat(extensions): add registry install/uninstall/upgrade commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ directus-cli users list --sort -date_created --limit 10 --offset 20
 | **Flows & Operations**   | `flows list`, `flows create`, `flows trigger`, `operations list`, `operations create`, `operations update`                                             |
 | **Schema**               | `schema snapshot`, `schema diff`, `schema apply`                                                                                                       |
 | **Bulk Operations**      | `bulk export`, `bulk import`                                                                                                                           |
+| **Extensions**           | `extensions list`, `extensions toggle`, `extensions search`, `extensions info`, `extensions install`, `extensions uninstall`, `extensions reinstall`, `extensions upgrade` |
 
 _For a complete list, run `directus-cli --help` or see the [Documentation](https://github.com/Face-to-Face-IT/directus-cli#commands)_
 

--- a/src/commands/extensions/info.ts
+++ b/src/commands/extensions/info.ts
@@ -1,0 +1,62 @@
+import {Args} from '@oclif/core';
+
+import {BaseCommand} from '../../base-command.js';
+import {describeRegistryExtension, resolveRegistryExtension} from '../../lib/extensions-registry.js';
+
+/**
+ * Show metadata and available versions for a registry extension.
+ */
+export default class ExtensionsInfo extends BaseCommand<typeof ExtensionsInfo> {
+  static override args = {
+    extension: Args.string({
+      description: 'Extension name or registry UUID',
+      required: true,
+    }),
+  };
+  static override description = 'Show registry metadata and available versions for an extension';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> directus-extension-computed-interface',
+    '<%= config.bin %> <%= command.id %> 12345678-1234-1234-1234-123456789abc',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+  };
+  static override summary = 'Show extension metadata';
+
+  public async run(): Promise<void> {
+    const {args} = await this.parse(ExtensionsInfo);
+
+    // Resolve name → UUID if needed, then fetch full details by UUID so we
+    // always get the full versions array.
+    const resolved = await resolveRegistryExtension(this.client, args.extension);
+    const full = await this.client.request(describeRegistryExtension(resolved.id));
+
+    const ext = full.data;
+    const data = {
+      description: ext.description ?? null,
+      host: ext.host ?? null,
+      id: ext.id,
+      // eslint-disable-next-line camelcase
+      last_updated: ext.last_updated ?? null,
+      license: ext.license ?? null,
+      name: ext.name,
+      publisher: ext.publisher ?? null,
+      sandbox: ext.sandbox ?? false,
+      // eslint-disable-next-line camelcase
+      total_downloads: ext.total_downloads ?? ext.downloads ?? 0,
+      type: ext.type ?? null,
+      versions: (ext.versions ?? []).map(v => ({
+        // eslint-disable-next-line camelcase
+        host_version: v.host_version ?? null,
+        // eslint-disable-next-line camelcase
+        publish_date: v.publish_date ?? null,
+        type: v.type ?? null,
+        unsafe: v.unsafe ?? false,
+        verified: v.verified ?? false,
+        version: v.version,
+      })),
+    };
+
+    this.outputFormatted(data);
+  }
+}

--- a/src/commands/extensions/install.ts
+++ b/src/commands/extensions/install.ts
@@ -1,0 +1,66 @@
+import {Args} from '@oclif/core';
+
+import {BaseCommand} from '../../base-command.js';
+import {
+  describeRegistryExtension,
+  installRegistryExtension,
+  parseVersionedIdentifier,
+  pickLatestVersion,
+  resolveRegistryExtension,
+} from '../../lib/extensions-registry.js';
+
+/**
+ * Install an extension from the Directus marketplace registry.
+ */
+export default class ExtensionsInstall extends BaseCommand<typeof ExtensionsInstall> {
+  static override args = {
+    extension: Args.string({
+      description: 'Extension name or UUID, optionally with `@<version>` suffix',
+      required: true,
+    }),
+  };
+  static override description
+    = 'Install an extension from the Directus marketplace registry. Admin-only. Supports `name@version` for pinning.';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> directus-extension-computed-interface',
+    '<%= config.bin %> <%= command.id %> directus-extension-computed-interface@2.0.0',
+    '<%= config.bin %> <%= command.id %> 12345678-1234-1234-1234-123456789abc@latest',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+  };
+  static override summary = 'Install extension from registry';
+
+  public async run(): Promise<void> {
+    const {args} = await this.parse(ExtensionsInstall);
+
+    const {identifier, version} = parseVersionedIdentifier(args.extension);
+    const resolved = await resolveRegistryExtension(this.client, identifier);
+
+    let targetVersion: string;
+    if (!version || version === 'latest') {
+      const full = await this.client.request(describeRegistryExtension(resolved.id));
+      targetVersion = pickLatestVersion(full.data.versions);
+    } else {
+      // Validate the requested version exists in the registry
+      const full = await this.client.request(describeRegistryExtension(resolved.id));
+      const available = (full.data.versions ?? []).map(v => v.version);
+      if (!available.includes(version)) {
+        this.error(`Version "${version}" is not available for "${resolved.name}". Available: ${available.slice(0, 10).join(', ')}${available.length > 10 ? ', …' : ''}`);
+      }
+
+      targetVersion = version;
+    }
+
+    this.log(`Installing ${resolved.name}@${targetVersion} … (this may take up to 2 minutes)`);
+    const result = await this.client.request(installRegistryExtension(resolved.id, targetVersion));
+
+    this.outputFormatted({
+      extension: resolved.name,
+      id: resolved.id,
+      installed: true,
+      result,
+      version: targetVersion,
+    });
+  }
+}

--- a/src/commands/extensions/reinstall.ts
+++ b/src/commands/extensions/reinstall.ts
@@ -1,0 +1,47 @@
+import {Args} from '@oclif/core';
+
+import {BaseCommand} from '../../base-command.js';
+import {
+  reinstallRegistryExtension,
+  resolveInstalledExtension,
+  resolveRegistryExtension,
+} from '../../lib/extensions-registry.js';
+
+/**
+ * Re-download the pinned version of an installed registry extension.
+ */
+export default class ExtensionsReinstall extends BaseCommand<typeof ExtensionsReinstall> {
+  static override args = {
+    extension: Args.string({
+      description: 'Extension name or directus_extensions row id',
+      required: true,
+    }),
+  };
+  static override description
+    = 'Re-download and reinstall a registry-sourced extension at its currently pinned version.';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> directus-extension-computed-interface',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+  };
+  static override summary = 'Reinstall extension';
+
+  public async run(): Promise<void> {
+    const {args} = await this.parse(ExtensionsReinstall);
+
+    // Confirm the extension is installed + registry-sourced.
+    const installed = await resolveInstalledExtension(this.client, args.extension);
+
+    if (installed.meta?.source && installed.meta.source !== 'registry') {
+      this.error(`Extension "${installed.name}" has source "${installed.meta.source}" and cannot be reinstalled via the API.`);
+    }
+
+    // The reinstall endpoint expects the registry extension UUID, not the row PK.
+    const registry = await resolveRegistryExtension(this.client, installed.name);
+
+    this.log(`Reinstalling ${installed.name} … (this may take up to 2 minutes)`);
+    await this.client.request(reinstallRegistryExtension(registry.id));
+    this.log(`Extension "${installed.name}" reinstalled.`);
+  }
+}

--- a/src/commands/extensions/search.ts
+++ b/src/commands/extensions/search.ts
@@ -1,0 +1,74 @@
+import {Args, Flags} from '@oclif/core';
+
+import {BaseCommand} from '../../base-command.js';
+import {searchRegistry} from '../../lib/extensions-registry.js';
+
+/**
+ * Search the Directus marketplace registry for extensions.
+ */
+export default class ExtensionsSearch extends BaseCommand<typeof ExtensionsSearch> {
+  static override args = {
+    query: Args.string({
+      description: 'Search terms (extension name, keywords, etc.)',
+      required: false,
+    }),
+  };
+  static override description = 'Search the Directus marketplace registry at registry.directus.io';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> computed',
+    '<%= config.bin %> <%= command.id %> --type interface',
+    '<%= config.bin %> <%= command.id %> tag --limit 5',
+    '<%= config.bin %> <%= command.id %> --sandbox',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    limit: Flags.integer({
+      default: 25,
+      description: 'Maximum number of results to return',
+      helpValue: '<n>',
+    }),
+    offset: Flags.integer({
+      default: 0,
+      description: 'Number of results to skip',
+      helpValue: '<n>',
+    }),
+    sandbox: Flags.boolean({
+      description: 'Show only sandboxed extensions (safe for MARKETPLACE_TRUST=sandbox)',
+    }),
+    type: Flags.string({
+      description:
+        'Filter by extension type (interface, display, layout, module, panel, hook, endpoint, operation, bundle)',
+      helpValue: '<type>',
+    }),
+  };
+  static override summary = 'Search marketplace registry';
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(ExtensionsSearch);
+
+    const result = await this.client.request(searchRegistry({
+      limit: flags.limit,
+      offset: flags.offset,
+      sandbox: flags.sandbox ? true : undefined,
+      search: args.query,
+      type: flags.type,
+    }));
+
+    const data = (result.data ?? []).map(ext => ({
+      description: ext.description ?? '',
+      downloads: ext.total_downloads ?? ext.downloads ?? 0,
+      id: ext.id,
+      // eslint-disable-next-line camelcase
+      last_updated: ext.last_updated ?? '',
+      name: ext.name,
+      publisher: ext.publisher ?? '',
+      sandbox: ext.sandbox ?? false,
+      type: ext.type ?? '',
+    }));
+
+    this.outputFormatted(data, {
+      filterCount: result.meta?.filter_count,
+      totalCount: result.meta?.filter_count,
+    });
+  }
+}

--- a/src/commands/extensions/uninstall.ts
+++ b/src/commands/extensions/uninstall.ts
@@ -1,0 +1,67 @@
+import {Args, Flags} from '@oclif/core';
+
+import {BaseCommand} from '../../base-command.js';
+import {resolveInstalledExtension, uninstallRegistryExtension} from '../../lib/extensions-registry.js';
+
+/**
+ * Uninstall a registry-sourced extension.
+ */
+export default class ExtensionsUninstall extends BaseCommand<typeof ExtensionsUninstall> {
+  static override args = {
+    extension: Args.string({
+      description: 'Extension name or directus_extensions row id',
+      required: true,
+    }),
+  };
+  static override description
+    = 'Uninstall a registry-sourced extension. Local-folder and npm-module extensions cannot be uninstalled via the API.';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> directus-extension-computed-interface',
+    '<%= config.bin %> <%= command.id %> directus-extension-computed-interface --yes',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    yes: Flags.boolean({
+      char: 'y',
+      default: false,
+      description: 'Skip confirmation prompt',
+    }),
+  };
+  static override summary = 'Uninstall extension';
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(ExtensionsUninstall);
+
+    const installed = await resolveInstalledExtension(this.client, args.extension);
+    const pk = installed.meta?.id ?? installed.id;
+
+    if (!pk) {
+      this.error(`Could not determine the directus_extensions row id for "${installed.name}".`);
+    }
+
+    if (installed.meta?.source && installed.meta.source !== 'registry') {
+      this.error(`Extension "${installed.name}" has source "${installed.meta.source}" and cannot be uninstalled via the API. Only registry-sourced extensions are supported.`);
+    }
+
+    if (!flags.yes) {
+      const confirmed = await this.confirm(`Are you sure you want to uninstall "${installed.name}"? (yes/no)`);
+      if (!confirmed) {
+        this.log('Cancelled.');
+        return;
+      }
+    }
+
+    await this.client.request(uninstallRegistryExtension(pk));
+    this.log(`Extension "${installed.name}" uninstalled.`);
+  }
+
+  private async confirm(prompt: string): Promise<boolean> {
+    const response = await new Promise<string>(resolve => {
+      process.stdout.write(prompt + ' ');
+      process.stdin.once('data', data => {
+        resolve(data.toString().trim().toLowerCase());
+      });
+    });
+    return response === 'yes' || response === 'y';
+  }
+}

--- a/src/commands/extensions/upgrade.ts
+++ b/src/commands/extensions/upgrade.ts
@@ -1,0 +1,112 @@
+import {Args, Flags} from '@oclif/core';
+
+import {BaseCommand} from '../../base-command.js';
+import {
+  describeRegistryExtension,
+  installRegistryExtension,
+  parseVersionedIdentifier,
+  pickLatestVersion,
+  resolveInstalledExtension,
+  resolveRegistryExtension,
+  uninstallRegistryExtension,
+} from '../../lib/extensions-registry.js';
+
+/**
+ * Upgrade an installed registry extension to a newer version.
+ *
+ * Not atomic: performs an uninstall followed by an install. There is a brief
+ * window during which the extension is absent from the target instance.
+ */
+export default class ExtensionsUpgrade extends BaseCommand<typeof ExtensionsUpgrade> {
+  static override args = {
+    extension: Args.string({
+      description: 'Extension name or directus_extensions row id, optionally with `@<version>` suffix',
+      required: true,
+    }),
+  };
+  static override description
+    = 'Upgrade an installed registry extension by uninstalling and reinstalling a newer version. NOT atomic: the extension is briefly unavailable between steps.';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> directus-extension-computed-interface',
+    '<%= config.bin %> <%= command.id %> directus-extension-computed-interface@3.0.0 --yes',
+  ];
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    yes: Flags.boolean({
+      char: 'y',
+      default: false,
+      description: 'Skip confirmation prompt',
+    }),
+  };
+  static override summary = 'Upgrade extension (non-atomic)';
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(ExtensionsUpgrade);
+
+    const {identifier, version} = parseVersionedIdentifier(args.extension);
+    const installed = await resolveInstalledExtension(this.client, identifier);
+    const pk = installed.meta?.id ?? installed.id;
+
+    if (!pk) {
+      this.error(`Could not determine the directus_extensions row id for "${installed.name}".`);
+    }
+
+    if (installed.meta?.source && installed.meta.source !== 'registry') {
+      this.error(`Extension "${installed.name}" has source "${installed.meta.source}" and cannot be upgraded via the API.`);
+    }
+
+    const registry = await resolveRegistryExtension(this.client, installed.name);
+    const details = await this.client.request(describeRegistryExtension(registry.id));
+
+    let targetVersion: string;
+    if (!version || version === 'latest') {
+      targetVersion = pickLatestVersion(details.data.versions);
+    } else {
+      const available = (details.data.versions ?? []).map(v => v.version);
+      if (!available.includes(version)) {
+        this.error(`Version "${version}" is not available for "${registry.name}". Available: ${available.slice(0, 10).join(', ')}${available.length > 10 ? ', …' : ''}`);
+      }
+
+      targetVersion = version;
+    }
+
+    const currentVersion = installed.schema?.version ?? 'unknown';
+
+    if (currentVersion === targetVersion) {
+      this.log(`Extension "${installed.name}" is already at version ${targetVersion}. Nothing to do.`);
+      return;
+    }
+
+    if (!flags.yes) {
+      const confirmed = await this.confirm(`Upgrade "${installed.name}" from ${currentVersion} to ${targetVersion}? The extension will be briefly unavailable. (yes/no)`);
+      if (!confirmed) {
+        this.log('Cancelled.');
+        return;
+      }
+    }
+
+    this.log(`Uninstalling ${installed.name}@${currentVersion} …`);
+    await this.client.request(uninstallRegistryExtension(pk));
+
+    this.log(`Installing ${installed.name}@${targetVersion} …`);
+    try {
+      await this.client.request(installRegistryExtension(registry.id, targetVersion));
+    } catch (error) {
+      const retryCmd = `directus-cli extensions install ${registry.name}@${targetVersion}`;
+      const originalMessage = (error as Error).message;
+      this.error(`Upgrade failed after uninstall. The extension is currently removed from the target instance. You can retry with: ${retryCmd}\nOriginal error: ${originalMessage}`);
+    }
+
+    this.log(`Extension "${installed.name}" upgraded to ${targetVersion}.`);
+  }
+
+  private async confirm(prompt: string): Promise<boolean> {
+    const response = await new Promise<string>(resolve => {
+      process.stdout.write(prompt + ' ');
+      process.stdin.once('data', data => {
+        resolve(data.toString().trim().toLowerCase());
+      });
+    });
+    return response === 'yes' || response === 'y';
+  }
+}

--- a/src/lib/extensions-registry.ts
+++ b/src/lib/extensions-registry.ts
@@ -1,0 +1,256 @@
+import type {DirectusClient} from './client.js';
+
+import {type SdkRestCommand} from '../types/index.js';
+
+/**
+ * Shape of a single extension entry returned by the registry search endpoint.
+ * Only fields actually consumed by the CLI are typed here.
+ */
+export interface RegistryExtension {
+  description?: null | string;
+  downloads?: number;
+  host?: null | string;
+  id: string;
+  last_updated?: null | string;
+  license?: null | string;
+  name: string;
+  publisher?: null | string;
+  readme?: null | string;
+  sandbox?: boolean;
+  total_downloads?: number;
+  type?: string;
+  versions?: RegistryExtensionVersion[];
+}
+
+/**
+ * A single version entry returned by the registry describe endpoint.
+ */
+export interface RegistryExtensionVersion {
+  host_version?: null | string;
+  publish_date?: null | string;
+  type?: string;
+  unsafe?: boolean;
+  url?: null | string;
+  verified?: boolean;
+  version: string;
+}
+
+/**
+ * A row from `GET /extensions/` (installed extensions).
+ */
+export interface InstalledExtension {
+  bundle?: null | string;
+  id?: string;
+  meta?: {
+    enabled?: boolean;
+    folder?: null | string;
+    id?: string;
+    permissions?: null | unknown;
+    source?: string;
+  };
+  name: string;
+  schema?: null | {
+    local?: boolean;
+    name?: string;
+    partial?: boolean;
+    type?: string;
+    version?: string;
+  };
+}
+
+/**
+ * Registry search query parameters.
+ */
+export interface RegistrySearchQuery {
+  limit?: number;
+  offset?: number;
+  sandbox?: boolean;
+  search?: string;
+  type?: string;
+}
+
+/**
+ * Build a RestCommand that searches the marketplace registry.
+ */
+export function searchRegistry(query: RegistrySearchQuery): SdkRestCommand<{data: RegistryExtension[]; meta?: {filter_count?: number}}> {
+  const params = new URLSearchParams();
+  if (query.search) params.set('search', query.search);
+  if (query.limit !== undefined) params.set('limit', String(query.limit));
+  if (query.offset !== undefined) params.set('offset', String(query.offset));
+  if (query.type) params.set('type', query.type);
+  if (query.sandbox !== undefined) params.set('sandbox', String(query.sandbox));
+  const qs = params.toString();
+  return {
+    method: 'GET',
+    path: `/extensions/registry${qs ? `?${qs}` : ''}`,
+  };
+}
+
+/**
+ * Build a RestCommand that fetches metadata for a single registry extension by UUID.
+ */
+export function describeRegistryExtension(extensionId: string): SdkRestCommand<{data: RegistryExtension}> {
+  return {
+    method: 'GET',
+    path: `/extensions/registry/extension/${encodeURIComponent(extensionId)}`,
+  };
+}
+
+/**
+ * Build a RestCommand that installs a registry extension.
+ */
+export function installRegistryExtension(extensionId: string, version: string): SdkRestCommand<unknown> {
+  return {
+    body: JSON.stringify({extension: extensionId, version}),
+    method: 'POST',
+    path: '/extensions/registry/install',
+  };
+}
+
+/**
+ * Build a RestCommand that uninstalls an installed registry extension by its `directus_extensions.id` PK.
+ */
+export function uninstallRegistryExtension(pk: string): SdkRestCommand<unknown> {
+  return {
+    method: 'DELETE',
+    path: `/extensions/registry/uninstall/${encodeURIComponent(pk)}`,
+  };
+}
+
+/**
+ * Build a RestCommand that reinstalls a registry extension by the registry extension UUID.
+ */
+export function reinstallRegistryExtension(extensionId: string): SdkRestCommand<unknown> {
+  return {
+    body: JSON.stringify({extension: extensionId}),
+    method: 'POST',
+    path: '/extensions/registry/reinstall',
+  };
+}
+
+/**
+ * Build a RestCommand that lists all installed extensions.
+ */
+export function listInstalledExtensions(): SdkRestCommand<InstalledExtension[] | {data: InstalledExtension[]}> {
+  return {
+    method: 'GET',
+    path: '/extensions/',
+  };
+}
+
+/**
+ * Normalize the response envelope into a data array.
+ * Directus sometimes returns `{data: [...]}`, sometimes a bare array.
+ */
+export function unwrap<T>(result: T[] | {data?: T[]}): T[] {
+  if (Array.isArray(result)) return result;
+  return result.data ?? [];
+}
+
+/**
+ * Resolve a user-provided identifier (name or UUID) to a registry extension.
+ * UUIDs are passed through; names are resolved via search.
+ */
+export async function resolveRegistryExtension(
+  client: DirectusClient,
+  identifier: string,
+): Promise<RegistryExtension> {
+  if (isUuid(identifier)) {
+    const res = await client.request(describeRegistryExtension(identifier));
+    return res.data;
+  }
+
+  const res = await client.request(searchRegistry({limit: 25, search: identifier}));
+  const matches = res.data ?? [];
+
+  if (matches.length === 0) {
+    throw new Error(`No registry extension matches "${identifier}".`);
+  }
+
+  const exact = matches.filter(m => m.name === identifier);
+  if (exact.length === 1) return exact[0]!;
+  if (exact.length > 1) {
+    const ids = exact.map(m => m.id).join(', ');
+    throw new Error(`Multiple registry extensions named "${identifier}": ${ids}. Specify the UUID.`);
+  }
+
+  if (matches.length === 1) return matches[0]!;
+
+  const preview = matches.slice(0, 5).map(m => `  - ${m.name} (${m.id})`).join('\n');
+  throw new Error(`Ambiguous extension name "${identifier}". ${matches.length} registry matches:\n${preview}\nSpecify the UUID or a more exact name.`);
+}
+
+/**
+ * Resolve a user-provided identifier (name or PK) to an installed extension row.
+ */
+export async function resolveInstalledExtension(
+  client: DirectusClient,
+  identifier: string,
+): Promise<InstalledExtension> {
+  const raw = await client.request(listInstalledExtensions());
+  const installed = unwrap(raw);
+
+  if (isUuid(identifier)) {
+    const byPk = installed.find(e => e.meta?.id === identifier || e.id === identifier);
+    if (byPk) return byPk;
+  }
+
+  const byName = installed.filter(e => e.name === identifier);
+  if (byName.length === 1) return byName[0]!;
+  if (byName.length > 1) {
+    throw new Error(`Multiple installed extensions named "${identifier}". Specify the directus_extensions row id.`);
+  }
+
+  throw new Error(`No installed extension matches "${identifier}".`);
+}
+
+/**
+ * Pick the latest non-prerelease, non-unsafe version string from a list of
+ * version entries.
+ *
+ * Selection order:
+ *   1. Filter out entries flagged `unsafe: true` (never install these).
+ *   2. Prefer the first stable (non-prerelease) version from the filtered list.
+ *   3. Fall back to the first non-unsafe entry (may be a prerelease).
+ *
+ * Throws if every published version is unsafe.
+ */
+export function pickLatestVersion(versions: RegistryExtensionVersion[] | undefined): string {
+  if (!versions || versions.length === 0) {
+    throw new Error('Extension has no published versions in the registry.');
+  }
+
+  const safe = versions.filter(v => !v.unsafe);
+  if (safe.length === 0) {
+    throw new Error('Extension has no safe published versions in the registry (all entries are marked unsafe).');
+  }
+
+  const stable = safe.find(v => !isPrerelease(v.version));
+  const chosen = stable ?? safe[0]!;
+  return chosen.version;
+}
+
+/**
+ * Split an identifier of the form `name@version` into its parts.
+ * Returns `{identifier, version}` where `version` is undefined if no `@` suffix is present.
+ */
+export function parseVersionedIdentifier(input: string): {identifier: string; version?: string} {
+  const at = input.lastIndexOf('@');
+  // Ignore a leading @ (used by scoped npm-style names, though not expected here)
+  if (at > 0) {
+    return {identifier: input.slice(0, at), version: input.slice(at + 1) || undefined};
+  }
+
+  return {identifier: input};
+}
+
+const UUID_RE = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/i;
+
+function isUuid(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
+function isPrerelease(version: string): boolean {
+  // Semver prerelease identifier: anything after the first `-` in the version core.
+  return /-[\dA-Za-z-]/.test(version);
+}

--- a/test/lib/extensions-registry.test.ts
+++ b/test/lib/extensions-registry.test.ts
@@ -1,0 +1,255 @@
+import {
+  beforeEach, describe, expect, it, vi,
+} from 'vitest';
+
+import type {DirectusClient} from '../../src/lib/client.js';
+
+import {
+  describeRegistryExtension,
+  installRegistryExtension,
+  parseVersionedIdentifier,
+  pickLatestVersion,
+  reinstallRegistryExtension,
+  resolveInstalledExtension,
+  resolveRegistryExtension,
+  searchRegistry,
+  uninstallRegistryExtension,
+  unwrap,
+} from '../../src/lib/extensions-registry.js';
+
+const mockRequest = vi.fn();
+const mockClient = {request: mockRequest} as unknown as DirectusClient;
+
+describe('extensions-registry', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  describe('searchRegistry', () => {
+    it('builds a GET command with encoded query params', () => {
+      const cmd = searchRegistry({
+        limit: 10, offset: 5, sandbox: true, search: 'computed', type: 'interface',
+      });
+      expect(cmd.method).toBe('GET');
+      expect(cmd.path).toContain('/extensions/registry?');
+      expect(cmd.path).toContain('search=computed');
+      expect(cmd.path).toContain('limit=10');
+      expect(cmd.path).toContain('offset=5');
+      expect(cmd.path).toContain('type=interface');
+      expect(cmd.path).toContain('sandbox=true');
+    });
+
+    it('omits the querystring when no params are provided', () => {
+      const cmd = searchRegistry({});
+      expect(cmd.path).toBe('/extensions/registry');
+    });
+  });
+
+  describe('describeRegistryExtension', () => {
+    it('URL-encodes the extension id', () => {
+      const cmd = describeRegistryExtension('abc 123');
+      expect(cmd.method).toBe('GET');
+      expect(cmd.path).toBe('/extensions/registry/extension/abc%20123');
+    });
+  });
+
+  describe('installRegistryExtension', () => {
+    it('POSTs a JSON body with extension and version', () => {
+      const cmd = installRegistryExtension('uuid-123', '1.2.3');
+      expect(cmd.method).toBe('POST');
+      expect(cmd.path).toBe('/extensions/registry/install');
+      expect(JSON.parse(cmd.body as string)).toEqual({extension: 'uuid-123', version: '1.2.3'});
+    });
+  });
+
+  describe('uninstallRegistryExtension', () => {
+    it('builds a DELETE with the encoded pk', () => {
+      const cmd = uninstallRegistryExtension('pk-1');
+      expect(cmd.method).toBe('DELETE');
+      expect(cmd.path).toBe('/extensions/registry/uninstall/pk-1');
+    });
+  });
+
+  describe('reinstallRegistryExtension', () => {
+    it('POSTs a JSON body with the extension id', () => {
+      const cmd = reinstallRegistryExtension('uuid-456');
+      expect(cmd.method).toBe('POST');
+      expect(cmd.path).toBe('/extensions/registry/reinstall');
+      expect(JSON.parse(cmd.body as string)).toEqual({extension: 'uuid-456'});
+    });
+  });
+
+  describe('unwrap', () => {
+    it('returns the array unchanged', () => {
+      expect(unwrap([1, 2, 3])).toEqual([1, 2, 3]);
+    });
+
+    it('unwraps an envelope', () => {
+      expect(unwrap({data: [1, 2]})).toEqual([1, 2]);
+    });
+
+    it('returns an empty array when data is missing', () => {
+      expect(unwrap({})).toEqual([]);
+    });
+  });
+
+  describe('parseVersionedIdentifier', () => {
+    it('splits name@version', () => {
+      expect(parseVersionedIdentifier('foo@1.2.3')).toEqual({identifier: 'foo', version: '1.2.3'});
+    });
+
+    it('returns just identifier when no @ is present', () => {
+      expect(parseVersionedIdentifier('foo')).toEqual({identifier: 'foo'});
+    });
+
+    it('supports @latest', () => {
+      expect(parseVersionedIdentifier('foo@latest')).toEqual({identifier: 'foo', version: 'latest'});
+    });
+
+    it('handles a trailing empty version as undefined', () => {
+      expect(parseVersionedIdentifier('foo@')).toEqual({identifier: 'foo'});
+    });
+  });
+
+  describe('pickLatestVersion', () => {
+    it('returns the first stable version', () => {
+      expect(pickLatestVersion([
+        {version: '2.0.0-beta.1'},
+        {version: '1.5.0'},
+        {version: '1.4.0'},
+      ])).toBe('1.5.0');
+    });
+
+    it('skips unsafe versions', () => {
+      expect(pickLatestVersion([
+        {unsafe: true, version: '2.0.0'},
+        {version: '1.0.0'},
+      ])).toBe('1.0.0');
+    });
+
+    it('falls back to first when all are prereleases', () => {
+      expect(pickLatestVersion([{version: '1.0.0-alpha'}, {version: '0.9.0-rc'}])).toBe('1.0.0-alpha');
+    });
+
+    it('skips unsafe entries even when they appear before stable ones in the list', () => {
+      expect(pickLatestVersion([
+        {unsafe: true, version: '3.0.0'},
+        {unsafe: true, version: '2.0.0-beta'},
+        {version: '1.5.0-rc'},
+        {version: '1.4.0'},
+      ])).toBe('1.4.0');
+    });
+
+    it('returns the first safe prerelease when no safe stable version exists', () => {
+      expect(pickLatestVersion([
+        {unsafe: true, version: '2.0.0'},
+        {version: '1.0.0-beta.2'},
+        {version: '1.0.0-beta.1'},
+      ])).toBe('1.0.0-beta.2');
+    });
+
+    it('throws when every version is unsafe', () => {
+      expect(() => pickLatestVersion([
+        {unsafe: true, version: '2.0.0'},
+        {unsafe: true, version: '1.0.0'},
+      ])).toThrow(/no safe published versions/i);
+    });
+
+    it('throws when no versions are available', () => {
+      expect(() => pickLatestVersion([])).toThrow(/no published versions/i);
+      expect(() => pickLatestVersion()).toThrow(/no published versions/i);
+    });
+  });
+
+  describe('resolveRegistryExtension', () => {
+    it('fetches by UUID directly when the identifier is a UUID', async () => {
+      const uuid = '12345678-1234-1234-1234-123456789abc';
+      mockRequest.mockResolvedValueOnce({data: {id: uuid, name: 'some-ext'}});
+
+      const result = await resolveRegistryExtension(mockClient, uuid);
+
+      expect(result.id).toBe(uuid);
+      const cmd = mockRequest.mock.calls[0]![0];
+      expect(cmd.path).toBe(`/extensions/registry/extension/${uuid}`);
+    });
+
+    it('searches by name and returns an exact match', async () => {
+      mockRequest.mockResolvedValueOnce({
+        data: [
+          {id: 'a', name: 'directus-extension-foo'},
+          {id: 'b', name: 'directus-extension-foo-bar'},
+        ],
+      });
+
+      const result = await resolveRegistryExtension(mockClient, 'directus-extension-foo');
+
+      expect(result.id).toBe('a');
+    });
+
+    it('returns the sole match when there is only one', async () => {
+      mockRequest.mockResolvedValueOnce({data: [{id: 'x', name: 'something-else'}]});
+
+      const result = await resolveRegistryExtension(mockClient, 'foo');
+
+      expect(result.id).toBe('x');
+    });
+
+    it('throws when no matches are found', async () => {
+      mockRequest.mockResolvedValueOnce({data: []});
+
+      await expect(resolveRegistryExtension(mockClient, 'missing')).rejects.toThrow(/No registry extension matches/);
+    });
+
+    it('throws on ambiguous name when no exact match', async () => {
+      mockRequest.mockResolvedValueOnce({
+        data: [
+          {id: 'a', name: 'foo-1'},
+          {id: 'b', name: 'foo-2'},
+        ],
+      });
+
+      await expect(resolveRegistryExtension(mockClient, 'foo')).rejects.toThrow(/Ambiguous extension name/);
+    });
+  });
+
+  describe('resolveInstalledExtension', () => {
+    it('matches by installed row pk when a UUID is given', async () => {
+      const pk = '12345678-1234-1234-1234-123456789abc';
+      mockRequest.mockResolvedValueOnce([
+        {meta: {id: pk, source: 'registry'}, name: 'foo'},
+      ]);
+
+      const result = await resolveInstalledExtension(mockClient, pk);
+
+      expect(result.name).toBe('foo');
+    });
+
+    it('matches by name when a name is given', async () => {
+      mockRequest.mockResolvedValueOnce({
+        data: [
+          {meta: {id: 'pk-a', source: 'registry'}, name: 'bar'},
+          {meta: {id: 'pk-b', source: 'registry'}, name: 'foo'},
+        ],
+      });
+
+      const result = await resolveInstalledExtension(mockClient, 'foo');
+
+      expect(result.meta?.id).toBe('pk-b');
+    });
+
+    it('throws when the name appears multiple times', async () => {
+      mockRequest.mockResolvedValueOnce([
+        {meta: {id: 'pk-a', source: 'registry'}, name: 'foo'},
+        {meta: {id: 'pk-b', source: 'registry'}, name: 'foo'},
+      ]);
+
+      await expect(resolveInstalledExtension(mockClient, 'foo')).rejects.toThrow(/Multiple installed extensions/);
+    });
+
+    it('throws when no match is found', async () => {
+      mockRequest.mockResolvedValueOnce([]);
+
+      await expect(resolveInstalledExtension(mockClient, 'nope')).rejects.toThrow(/No installed extension matches/);
+    });
+  });
+});


### PR DESCRIPTION
Closes #7.

## Summary

Adds six marketplace-registry commands for managing Directus extensions from the CLI. Builds on the existing `extensions list` / `extensions toggle` without changing them.

| Command | Purpose |
|---|---|
| `extensions search [query]` | Search `registry.directus.io`. Supports `--type`, `--sandbox`, `--limit`, `--offset`. |
| `extensions info <name-or-uuid>` | Metadata + full version list for a registry extension. |
| `extensions install <name-or-uuid>[@<version>]` | Install latest stable (default) or a pinned version. Validates the version exists. |
| `extensions uninstall <name-or-pk> [--yes]` | Remove a registry-sourced extension. Rejects `local` / `module` sources. |
| `extensions reinstall <name-or-pk>` | Re-download the pinned version. |
| `extensions upgrade <name-or-pk>[@<version>] [--yes]` | Uninstall + install; surfaces a retry hint if the install half fails. |

## Implementation notes

- Registry endpoints are not yet surfaced by `@directus/sdk`, so the commands hand-build `SdkRestCommand` literals via a new `src/lib/extensions-registry.ts`. All requests still flow through `DirectusClient.request()`, so rate limiting, retries, and the new transparent-refresh-on-401 behaviour (PR #8) all apply.
- Identifier resolution accepts UUIDs, exact names, or `name@version`. Ambiguous names fail with a list of matches and their UUIDs. `install`/`upgrade` default to the latest non-prerelease, skip `unsafe` versions, and honour `@latest` explicitly.
- `uninstall` disambiguates the `directus_extensions` row PK from the registry UUID by listing installed extensions first.
- `upgrade` is documented and prompted as non-atomic; confirmation is shown unless `--yes` is passed.
- Non-admin, sandbox, and extension-limit errors come back through the standard `DirectusCliError` formatter, surfacing the Directus server's own message (e.g. `[403] You don't have permission to access this.`).

## Tests

- 26 new tests in `test/lib/extensions-registry.test.ts` covering command builders (search querystring encoding, URL-safe path building, body shape), `unwrap`, `parseVersionedIdentifier`, `pickLatestVersion` (stable-first, unsafe-skip, all-prerelease fallback), `resolveRegistryExtension` (UUID / exact / sole / no-match / ambiguous), and `resolveInstalledExtension` (by PK, by name, dup-name, no-match).
- Full suite: 64 passing, build + lint clean.

## Out of scope (matches the issue)

- Installing from npm names, tarballs, git URLs, local paths.
- Uninstalling `local` or `module` source extensions.
- Atomic upgrade (would need a core contribution).