### PR TITLE
fix(extensions): return RestCommand functions so SDK can invoke them

### DIFF
--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -58,11 +58,22 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
 
     // Access verbose flag carefully - might not be available if init failed
     const flags = this.flags as unknown as undefined | {verbose?: boolean};
-    if (flags?.verbose && directusError.errors) {
-      for (const err of directusError.errors) {
-        if (err.extensions) {
-          parts.push(`\n  ${JSON.stringify(err.extensions)}`);
+    if (flags?.verbose) {
+      // Structured Directus error extensions (if any).
+      if (directusError.errors) {
+        for (const err of directusError.errors) {
+          if (err.extensions) {
+            parts.push(`\n  ${JSON.stringify(err.extensions)}`);
+          }
         }
+      }
+
+      // Preserve the original stack for non-Directus exceptions (e.g. a plain
+      // JS `TypeError` bubbling up from the SDK). Without this, users running
+      // `--verbose` see only the message and can't diagnose where it came from.
+      const stack = error?.stack;
+      if (stack) {
+        parts.push(`\n${stack}`);
       }
     }
 

--- a/src/lib/extensions-registry.ts
+++ b/src/lib/extensions-registry.ts
@@ -71,6 +71,10 @@ export interface RegistrySearchQuery {
 
 /**
  * Build a RestCommand that searches the marketplace registry.
+ *
+ * Note: the Directus SDK invokes commands as `command(client)`, so builders
+ * must return a function — not a plain object — or `client.request()` will
+ * throw `<arg> is not a function`.
  */
 export function searchRegistry(query: RegistrySearchQuery): SdkRestCommand<{data: RegistryExtension[]; meta?: {filter_count?: number}}> {
   const params = new URLSearchParams();
@@ -80,62 +84,62 @@ export function searchRegistry(query: RegistrySearchQuery): SdkRestCommand<{data
   if (query.type) params.set('type', query.type);
   if (query.sandbox !== undefined) params.set('sandbox', String(query.sandbox));
   const qs = params.toString();
-  return {
+  return () => ({
     method: 'GET',
     path: `/extensions/registry${qs ? `?${qs}` : ''}`,
-  };
+  });
 }
 
 /**
  * Build a RestCommand that fetches metadata for a single registry extension by UUID.
  */
 export function describeRegistryExtension(extensionId: string): SdkRestCommand<{data: RegistryExtension}> {
-  return {
+  return () => ({
     method: 'GET',
     path: `/extensions/registry/extension/${encodeURIComponent(extensionId)}`,
-  };
+  });
 }
 
 /**
  * Build a RestCommand that installs a registry extension.
  */
 export function installRegistryExtension(extensionId: string, version: string): SdkRestCommand<unknown> {
-  return {
+  return () => ({
     body: JSON.stringify({extension: extensionId, version}),
     method: 'POST',
     path: '/extensions/registry/install',
-  };
+  });
 }
 
 /**
  * Build a RestCommand that uninstalls an installed registry extension by its `directus_extensions.id` PK.
  */
 export function uninstallRegistryExtension(pk: string): SdkRestCommand<unknown> {
-  return {
+  return () => ({
     method: 'DELETE',
     path: `/extensions/registry/uninstall/${encodeURIComponent(pk)}`,
-  };
+  });
 }
 
 /**
  * Build a RestCommand that reinstalls a registry extension by the registry extension UUID.
  */
 export function reinstallRegistryExtension(extensionId: string): SdkRestCommand<unknown> {
-  return {
+  return () => ({
     body: JSON.stringify({extension: extensionId}),
     method: 'POST',
     path: '/extensions/registry/reinstall',
-  };
+  });
 }
 
 /**
  * Build a RestCommand that lists all installed extensions.
  */
 export function listInstalledExtensions(): SdkRestCommand<InstalledExtension[] | {data: InstalledExtension[]}> {
-  return {
+  return () => ({
     method: 'GET',
     path: '/extensions/',
-  };
+  });
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,15 +164,27 @@ export interface SdkQuery {
 
 /**
  * SDK RestCommand type.
- * This represents a command returned by SDK functions like readItems(),
- * readItem(), createItem(), etc.
+ *
+ * Commands returned by `@directus/sdk` functions (`readItems()`,
+ * `readItem()`, `createItem()`, etc.) are *functions* of the form
+ * `(client) => ({method, path, body, ...})`. The SDK invokes them as
+ * `command(client)` inside `client.request()`, which means a plain object
+ * command throws `<arg> is not a function`.
+ *
+ * We keep the type broad (unknown) because:
+ *  - All current call sites cast SDK builder results via `as unknown as
+ *    SdkRestCommand<T>` — the surface type is effectively a phantom carrier
+ *    for `TResult` inference.
+ *  - Custom builders in this repo (`src/lib/extensions-registry.ts`) must
+ *    return functions to be compatible with the SDK.
  */
-export interface SdkRestCommand<TResult> {
-  /** Type marker for the expected result type */
-  __resultType?: TResult;
+export type SdkRestCommand<TResult> = ((client?: unknown) => {
   body?: unknown;
   method: string;
   params?: unknown;
   path: string;
   query?: unknown;
-}
+}) & {
+  /** Type marker for the expected result type */
+  __resultType?: TResult;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -178,7 +178,7 @@ export interface SdkQuery {
  *  - Custom builders in this repo (`src/lib/extensions-registry.ts`) must
  *    return functions to be compatible with the SDK.
  */
-export type SdkRestCommand<TResult> = ((client?: unknown) => {
+export type SdkRestCommand<TResult> = ((client: unknown) => {
   body?: unknown;
   method: string;
   params?: unknown;

--- a/test/lib/extensions-registry.test.ts
+++ b/test/lib/extensions-registry.test.ts
@@ -29,7 +29,7 @@ describe('extensions-registry', () => {
     it('builds a GET command with encoded query params', () => {
       const cmd = searchRegistry({
         limit: 10, offset: 5, sandbox: true, search: 'computed', type: 'interface',
-      });
+      })();
       expect(cmd.method).toBe('GET');
       expect(cmd.path).toContain('/extensions/registry?');
       expect(cmd.path).toContain('search=computed');
@@ -40,14 +40,18 @@ describe('extensions-registry', () => {
     });
 
     it('omits the querystring when no params are provided', () => {
-      const cmd = searchRegistry({});
+      const cmd = searchRegistry({})();
       expect(cmd.path).toBe('/extensions/registry');
+    });
+
+    it('returns a function (RestCommand) so the SDK can invoke it', () => {
+      expect(typeof searchRegistry({})).toBe('function');
     });
   });
 
   describe('describeRegistryExtension', () => {
     it('URL-encodes the extension id', () => {
-      const cmd = describeRegistryExtension('abc 123');
+      const cmd = describeRegistryExtension('abc 123')();
       expect(cmd.method).toBe('GET');
       expect(cmd.path).toBe('/extensions/registry/extension/abc%20123');
     });
@@ -55,7 +59,7 @@ describe('extensions-registry', () => {
 
   describe('installRegistryExtension', () => {
     it('POSTs a JSON body with extension and version', () => {
-      const cmd = installRegistryExtension('uuid-123', '1.2.3');
+      const cmd = installRegistryExtension('uuid-123', '1.2.3')();
       expect(cmd.method).toBe('POST');
       expect(cmd.path).toBe('/extensions/registry/install');
       expect(JSON.parse(cmd.body as string)).toEqual({extension: 'uuid-123', version: '1.2.3'});
@@ -64,7 +68,7 @@ describe('extensions-registry', () => {
 
   describe('uninstallRegistryExtension', () => {
     it('builds a DELETE with the encoded pk', () => {
-      const cmd = uninstallRegistryExtension('pk-1');
+      const cmd = uninstallRegistryExtension('pk-1')();
       expect(cmd.method).toBe('DELETE');
       expect(cmd.path).toBe('/extensions/registry/uninstall/pk-1');
     });
@@ -72,7 +76,7 @@ describe('extensions-registry', () => {
 
   describe('reinstallRegistryExtension', () => {
     it('POSTs a JSON body with the extension id', () => {
-      const cmd = reinstallRegistryExtension('uuid-456');
+      const cmd = reinstallRegistryExtension('uuid-456')();
       expect(cmd.method).toBe('POST');
       expect(cmd.path).toBe('/extensions/registry/reinstall');
       expect(JSON.parse(cmd.body as string)).toEqual({extension: 'uuid-456'});
@@ -169,8 +173,8 @@ describe('extensions-registry', () => {
       const result = await resolveRegistryExtension(mockClient, uuid);
 
       expect(result.id).toBe(uuid);
-      const cmd = mockRequest.mock.calls[0]![0];
-      expect(cmd.path).toBe(`/extensions/registry/extension/${uuid}`);
+      const cmd = mockRequest.mock.calls[0]![0] as () => {path: string};
+      expect(cmd().path).toBe(`/extensions/registry/extension/${uuid}`);
     });
 
     it('searches by name and returns an exact match', async () => {

--- a/test/lib/extensions-registry.test.ts
+++ b/test/lib/extensions-registry.test.ts
@@ -29,7 +29,7 @@ describe('extensions-registry', () => {
     it('builds a GET command with encoded query params', () => {
       const cmd = searchRegistry({
         limit: 10, offset: 5, sandbox: true, search: 'computed', type: 'interface',
-      })();
+      })(mockClient);
       expect(cmd.method).toBe('GET');
       expect(cmd.path).toContain('/extensions/registry?');
       expect(cmd.path).toContain('search=computed');
@@ -40,7 +40,7 @@ describe('extensions-registry', () => {
     });
 
     it('omits the querystring when no params are provided', () => {
-      const cmd = searchRegistry({})();
+      const cmd = searchRegistry({})(mockClient);
       expect(cmd.path).toBe('/extensions/registry');
     });
 
@@ -51,7 +51,7 @@ describe('extensions-registry', () => {
 
   describe('describeRegistryExtension', () => {
     it('URL-encodes the extension id', () => {
-      const cmd = describeRegistryExtension('abc 123')();
+      const cmd = describeRegistryExtension('abc 123')(mockClient);
       expect(cmd.method).toBe('GET');
       expect(cmd.path).toBe('/extensions/registry/extension/abc%20123');
     });
@@ -59,7 +59,7 @@ describe('extensions-registry', () => {
 
   describe('installRegistryExtension', () => {
     it('POSTs a JSON body with extension and version', () => {
-      const cmd = installRegistryExtension('uuid-123', '1.2.3')();
+      const cmd = installRegistryExtension('uuid-123', '1.2.3')(mockClient);
       expect(cmd.method).toBe('POST');
       expect(cmd.path).toBe('/extensions/registry/install');
       expect(JSON.parse(cmd.body as string)).toEqual({extension: 'uuid-123', version: '1.2.3'});
@@ -68,7 +68,7 @@ describe('extensions-registry', () => {
 
   describe('uninstallRegistryExtension', () => {
     it('builds a DELETE with the encoded pk', () => {
-      const cmd = uninstallRegistryExtension('pk-1')();
+      const cmd = uninstallRegistryExtension('pk-1')(mockClient);
       expect(cmd.method).toBe('DELETE');
       expect(cmd.path).toBe('/extensions/registry/uninstall/pk-1');
     });
@@ -76,7 +76,7 @@ describe('extensions-registry', () => {
 
   describe('reinstallRegistryExtension', () => {
     it('POSTs a JSON body with the extension id', () => {
-      const cmd = reinstallRegistryExtension('uuid-456')();
+      const cmd = reinstallRegistryExtension('uuid-456')(mockClient);
       expect(cmd.method).toBe('POST');
       expect(cmd.path).toBe('/extensions/registry/reinstall');
       expect(JSON.parse(cmd.body as string)).toEqual({extension: 'uuid-456'});


### PR DESCRIPTION
## Summary
- Fixes #10: registry-backed extension commands (`install`, `reinstall`, `upgrade`, `info`, `search`, list) threw `n is not a function` because our custom REST command builders returned plain objects, while `@directus/sdk`'s `client.request(command)` invokes the command as a function (`command(client)`).
- All six builders in `src/lib/extensions-registry.ts` now return `() => ({ method, path, body, ... })`.
- `SdkRestCommand<T>` is redefined as a callable type with a phantom `__resultType` marker so the generic result type is preserved without changing every call site.
- `base-command.ts` now appends `error.stack` when `--verbose` is set to make future failures easier to diagnose.

## Test plan
- \`pnpm build\` ✅
- \`pnpm lint\` ✅
- \`pnpm test\` ✅ (94/94)
- Added a contract test asserting builders return functions; updated existing builder tests to invoke \`cmd()\` before asserting shape.

Fixes #10