### PR TITLE
fix(extensions): read extension name from schema.name

### DIFF
--- a/src/commands/extensions/list.ts
+++ b/src/commands/extensions/list.ts
@@ -38,19 +38,21 @@ export default class ExtensionsList extends BaseCommand<typeof ExtensionsList> {
 
     let data = Array.isArray(result) ? result : ((result as {data?: unknown[]}).data ?? []);
 
-    // Flatten extensions into a more useful shape for display
+    // Flatten extensions into a more useful shape for display.
+    // Note: the Directus API returns the canonical extension name at
+    // `schema.name`, not top-level `name` (which is usually absent).
     data = data.map((ext: unknown) => {
       const e = ext as {
         bundle?: null | string;
         meta?: {enabled?: boolean};
         name?: string;
-        schema?: null | {local?: boolean; type?: string; version?: string};
+        schema?: null | {local?: boolean; name?: string; type?: string; version?: string};
       };
       return {
         bundle: e.bundle ?? null,
         enabled: e.meta?.enabled ?? false,
         local: e.schema?.local ?? false,
-        name: e.name ?? 'unknown',
+        name: e.schema?.name ?? e.name ?? 'unknown',
         type: e.schema?.type ?? 'unknown',
         version: e.schema?.version ?? '-',
       };

--- a/src/commands/extensions/reinstall.ts
+++ b/src/commands/extensions/reinstall.ts
@@ -2,6 +2,7 @@ import {Args} from '@oclif/core';
 
 import {BaseCommand} from '../../base-command.js';
 import {
+  getInstalledExtensionName,
   reinstallRegistryExtension,
   resolveInstalledExtension,
   resolveRegistryExtension,
@@ -32,16 +33,17 @@ export default class ExtensionsReinstall extends BaseCommand<typeof ExtensionsRe
 
     // Confirm the extension is installed + registry-sourced.
     const installed = await resolveInstalledExtension(this.client, args.extension);
+    const name = getInstalledExtensionName(installed) ?? args.extension;
 
     if (installed.meta?.source && installed.meta.source !== 'registry') {
-      this.error(`Extension "${installed.name}" has source "${installed.meta.source}" and cannot be reinstalled via the API.`);
+      this.error(`Extension "${name}" has source "${installed.meta.source}" and cannot be reinstalled via the API.`);
     }
 
     // The reinstall endpoint expects the registry extension UUID, not the row PK.
-    const registry = await resolveRegistryExtension(this.client, installed.name);
+    const registry = await resolveRegistryExtension(this.client, name);
 
-    this.log(`Reinstalling ${installed.name} … (this may take up to 2 minutes)`);
+    this.log(`Reinstalling ${name} … (this may take up to 2 minutes)`);
     await this.client.request(reinstallRegistryExtension(registry.id));
-    this.log(`Extension "${installed.name}" reinstalled.`);
+    this.log(`Extension "${name}" reinstalled.`);
   }
 }

--- a/src/commands/extensions/uninstall.ts
+++ b/src/commands/extensions/uninstall.ts
@@ -1,7 +1,11 @@
 import {Args, Flags} from '@oclif/core';
 
 import {BaseCommand} from '../../base-command.js';
-import {resolveInstalledExtension, uninstallRegistryExtension} from '../../lib/extensions-registry.js';
+import {
+  getInstalledExtensionName,
+  resolveInstalledExtension,
+  uninstallRegistryExtension,
+} from '../../lib/extensions-registry.js';
 
 /**
  * Uninstall a registry-sourced extension.
@@ -34,17 +38,18 @@ export default class ExtensionsUninstall extends BaseCommand<typeof ExtensionsUn
 
     const installed = await resolveInstalledExtension(this.client, args.extension);
     const pk = installed.meta?.id ?? installed.id;
+    const name = getInstalledExtensionName(installed) ?? args.extension;
 
     if (!pk) {
-      this.error(`Could not determine the directus_extensions row id for "${installed.name}".`);
+      this.error(`Could not determine the directus_extensions row id for "${name}".`);
     }
 
     if (installed.meta?.source && installed.meta.source !== 'registry') {
-      this.error(`Extension "${installed.name}" has source "${installed.meta.source}" and cannot be uninstalled via the API. Only registry-sourced extensions are supported.`);
+      this.error(`Extension "${name}" has source "${installed.meta.source}" and cannot be uninstalled via the API. Only registry-sourced extensions are supported.`);
     }
 
     if (!flags.yes) {
-      const confirmed = await this.confirm(`Are you sure you want to uninstall "${installed.name}"? (yes/no)`);
+      const confirmed = await this.confirm(`Are you sure you want to uninstall "${name}"? (yes/no)`);
       if (!confirmed) {
         this.log('Cancelled.');
         return;
@@ -52,7 +57,7 @@ export default class ExtensionsUninstall extends BaseCommand<typeof ExtensionsUn
     }
 
     await this.client.request(uninstallRegistryExtension(pk));
-    this.log(`Extension "${installed.name}" uninstalled.`);
+    this.log(`Extension "${name}" uninstalled.`);
   }
 
   private async confirm(prompt: string): Promise<boolean> {

--- a/src/commands/extensions/upgrade.ts
+++ b/src/commands/extensions/upgrade.ts
@@ -3,6 +3,7 @@ import {Args, Flags} from '@oclif/core';
 import {BaseCommand} from '../../base-command.js';
 import {
   describeRegistryExtension,
+  getInstalledExtensionName,
   installRegistryExtension,
   parseVersionedIdentifier,
   pickLatestVersion,
@@ -46,16 +47,17 @@ export default class ExtensionsUpgrade extends BaseCommand<typeof ExtensionsUpgr
     const {identifier, version} = parseVersionedIdentifier(args.extension);
     const installed = await resolveInstalledExtension(this.client, identifier);
     const pk = installed.meta?.id ?? installed.id;
+    const name = getInstalledExtensionName(installed) ?? identifier;
 
     if (!pk) {
-      this.error(`Could not determine the directus_extensions row id for "${installed.name}".`);
+      this.error(`Could not determine the directus_extensions row id for "${name}".`);
     }
 
     if (installed.meta?.source && installed.meta.source !== 'registry') {
-      this.error(`Extension "${installed.name}" has source "${installed.meta.source}" and cannot be upgraded via the API.`);
+      this.error(`Extension "${name}" has source "${installed.meta.source}" and cannot be upgraded via the API.`);
     }
 
-    const registry = await resolveRegistryExtension(this.client, installed.name);
+    const registry = await resolveRegistryExtension(this.client, name);
     const details = await this.client.request(describeRegistryExtension(registry.id));
 
     let targetVersion: string;
@@ -73,22 +75,22 @@ export default class ExtensionsUpgrade extends BaseCommand<typeof ExtensionsUpgr
     const currentVersion = installed.schema?.version ?? 'unknown';
 
     if (currentVersion === targetVersion) {
-      this.log(`Extension "${installed.name}" is already at version ${targetVersion}. Nothing to do.`);
+      this.log(`Extension "${name}" is already at version ${targetVersion}. Nothing to do.`);
       return;
     }
 
     if (!flags.yes) {
-      const confirmed = await this.confirm(`Upgrade "${installed.name}" from ${currentVersion} to ${targetVersion}? The extension will be briefly unavailable. (yes/no)`);
+      const confirmed = await this.confirm(`Upgrade "${name}" from ${currentVersion} to ${targetVersion}? The extension will be briefly unavailable. (yes/no)`);
       if (!confirmed) {
         this.log('Cancelled.');
         return;
       }
     }
 
-    this.log(`Uninstalling ${installed.name}@${currentVersion} …`);
+    this.log(`Uninstalling ${name}@${currentVersion} …`);
     await this.client.request(uninstallRegistryExtension(pk));
 
-    this.log(`Installing ${installed.name}@${targetVersion} …`);
+    this.log(`Installing ${name}@${targetVersion} …`);
     try {
       await this.client.request(installRegistryExtension(registry.id, targetVersion));
     } catch (error) {
@@ -97,7 +99,7 @@ export default class ExtensionsUpgrade extends BaseCommand<typeof ExtensionsUpgr
       this.error(`Upgrade failed after uninstall. The extension is currently removed from the target instance. You can retry with: ${retryCmd}\nOriginal error: ${originalMessage}`);
     }
 
-    this.log(`Extension "${installed.name}" upgraded to ${targetVersion}.`);
+    this.log(`Extension "${name}" upgraded to ${targetVersion}.`);
   }
 
   private async confirm(prompt: string): Promise<boolean> {

--- a/src/lib/extensions-registry.ts
+++ b/src/lib/extensions-registry.ts
@@ -37,6 +37,10 @@ export interface RegistryExtensionVersion {
 
 /**
  * A row from `GET /extensions/` (installed extensions).
+ *
+ * The Directus API does not return a top-level `name` field for installed
+ * extensions — the extension name lives under `schema.name`. The top-level
+ * `name` is kept optional for forward compatibility but should not be relied on.
  */
 export interface InstalledExtension {
   bundle?: null | string;
@@ -48,7 +52,7 @@ export interface InstalledExtension {
     permissions?: null | unknown;
     source?: string;
   };
-  name: string;
+  name?: string;
   schema?: null | {
     local?: boolean;
     name?: string;
@@ -67,6 +71,14 @@ export interface RegistrySearchQuery {
   sandbox?: boolean;
   search?: string;
   type?: string;
+}
+
+/**
+ * Return the canonical name for an installed extension row.
+ * Prefers `schema.name` (authoritative) and falls back to top-level `name`.
+ */
+export function getInstalledExtensionName(e: InstalledExtension): string | undefined {
+  return e.schema?.name ?? e.name;
 }
 
 /**
@@ -186,6 +198,10 @@ export async function resolveRegistryExtension(
 
 /**
  * Resolve a user-provided identifier (name or PK) to an installed extension row.
+ *
+ * Matching order:
+ *   1. If identifier is a UUID, match by `meta.id` or `id` (row PK).
+ *   2. Match by extension name (`schema.name`, falling back to top-level `name`).
  */
 export async function resolveInstalledExtension(
   client: DirectusClient,
@@ -199,7 +215,7 @@ export async function resolveInstalledExtension(
     if (byPk) return byPk;
   }
 
-  const byName = installed.filter(e => e.name === identifier);
+  const byName = installed.filter(e => getInstalledExtensionName(e) === identifier);
   if (byName.length === 1) return byName[0]!;
   if (byName.length > 1) {
     throw new Error(`Multiple installed extensions named "${identifier}". Specify the directus_extensions row id.`);

--- a/test/lib/extensions-registry.test.ts
+++ b/test/lib/extensions-registry.test.ts
@@ -6,6 +6,7 @@ import type {DirectusClient} from '../../src/lib/client.js';
 
 import {
   describeRegistryExtension,
+  getInstalledExtensionName,
   installRegistryExtension,
   parseVersionedIdentifier,
   pickLatestVersion,
@@ -216,23 +217,37 @@ describe('extensions-registry', () => {
     });
   });
 
+  describe('getInstalledExtensionName', () => {
+    it('prefers schema.name', () => {
+      expect(getInstalledExtensionName({schema: {name: 'canonical'}, name: 'legacy'})).toBe('canonical');
+    });
+
+    it('falls back to top-level name', () => {
+      expect(getInstalledExtensionName({name: 'legacy'})).toBe('legacy');
+    });
+
+    it('returns undefined when neither is present', () => {
+      expect(getInstalledExtensionName({})).toBeUndefined();
+    });
+  });
+
   describe('resolveInstalledExtension', () => {
     it('matches by installed row pk when a UUID is given', async () => {
       const pk = '12345678-1234-1234-1234-123456789abc';
       mockRequest.mockResolvedValueOnce([
-        {meta: {id: pk, source: 'registry'}, name: 'foo'},
+        {meta: {id: pk, source: 'registry'}, schema: {name: 'foo'}},
       ]);
 
       const result = await resolveInstalledExtension(mockClient, pk);
 
-      expect(result.name).toBe('foo');
+      expect(result.schema?.name).toBe('foo');
     });
 
-    it('matches by name when a name is given', async () => {
+    it('matches by schema.name (the real API shape)', async () => {
       mockRequest.mockResolvedValueOnce({
         data: [
-          {meta: {id: 'pk-a', source: 'registry'}, name: 'bar'},
-          {meta: {id: 'pk-b', source: 'registry'}, name: 'foo'},
+          {meta: {id: 'pk-a', source: 'registry'}, schema: {name: 'bar'}},
+          {meta: {id: 'pk-b', source: 'registry'}, schema: {name: 'foo'}},
         ],
       });
 
@@ -241,10 +256,22 @@ describe('extensions-registry', () => {
       expect(result.meta?.id).toBe('pk-b');
     });
 
+    it('falls back to top-level name when schema.name is absent', async () => {
+      mockRequest.mockResolvedValueOnce({
+        data: [
+          {meta: {id: 'pk-a', source: 'registry'}, name: 'foo'},
+        ],
+      });
+
+      const result = await resolveInstalledExtension(mockClient, 'foo');
+
+      expect(result.meta?.id).toBe('pk-a');
+    });
+
     it('throws when the name appears multiple times', async () => {
       mockRequest.mockResolvedValueOnce([
-        {meta: {id: 'pk-a', source: 'registry'}, name: 'foo'},
-        {meta: {id: 'pk-b', source: 'registry'}, name: 'foo'},
+        {meta: {id: 'pk-a', source: 'registry'}, schema: {name: 'foo'}},
+        {meta: {id: 'pk-b', source: 'registry'}, schema: {name: 'foo'}},
       ]);
 
       await expect(resolveInstalledExtension(mockClient, 'foo')).rejects.toThrow(/Multiple installed extensions/);


### PR DESCRIPTION
## Summary
- Fixes #11: \`directus-cli extensions list\` displayed \`unknown\` for every extension, and \`reinstall\`/\`uninstall\`/\`upgrade\` could not resolve installed extensions by name. Root cause: the Directus API returns the extension name under \`schema.name\`, not as a top-level \`name\` field — our code only read the top-level field.
- \`InstalledExtension\`: top-level \`name\` is now optional; \`schema.name\` is the canonical source.
- New \`getInstalledExtensionName()\` helper (prefers \`schema.name\`, falls back to top-level \`name\`).
- \`list.ts\` flattens name via \`schema?.name ?? name ?? 'unknown'\`.
- \`reinstall\`/\`uninstall\`/\`upgrade\` resolve the display name via the helper and use it consistently in log/error messages and registry lookups.
- \`resolveInstalledExtension\` matches against \`schema.name\` with a fallback.

## Stacked on
- #12 — this PR targets \`fix/extensions-rest-command-functions\` as its base and should be rebased onto \`main\` after #12 merges.

## Test plan
- \`pnpm build\` ✅
- \`pnpm lint\` ✅
- \`pnpm test\` ✅ (98/98)
- Added tests for \`getInstalledExtensionName\`; updated resolver tests to use the \`schema.name\` shape.

Fixes #11