### PR TITLE
docs(skill): add agent skill files for directus-cli

### DIFF
--- a/skill/README.md
+++ b/skill/README.md
@@ -1,0 +1,15 @@
+# directus-cli agent skill
+
+Agent skill for `directus-cli`, loadable by OpenCode / Claude Code / any agent runtime that understands the [Anthropic skill format](https://docs.anthropic.com/).
+
+- `SKILL.md` — entry point with frontmatter, decision tree, and gotchas
+- `references/` — detailed reference docs loaded on demand
+
+## Install locally
+
+```bash
+# Copy into your user skills directory
+cp -r skill/* ~/.agents/skills/directus-cli/
+```
+
+This is the canonical source. Update files here, open a PR, then re-run the copy command after merge.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: directus-cli
+description: Use for managing Directus CMS instances from the command line with `directus-cli`. Triggers include Directus collection/field/item CRUD, user/role/policy management, schema snapshots and migrations, file uploads/downloads, bulk import/export, flow automation, dashboard/panel management, and Directus API operations.
+---
+
+# Directus CLI
+
+Use `directus-cli` to manage Directus CMS instances from the terminal. Wraps the Directus SDK with rate limiting, retry logic, and multi-profile support.
+
+## Workflow
+
+1. Install `directus-cli` (npm global, local, or npx). Read `references/install.md`.
+2. Authenticate (email/password login, static token, or profile).
+3. Discover commands via `directus-cli <topic> --help`.
+4. Use `--format json` for automation; pipe to `jq` for extraction.
+5. Use `--yes` to skip confirmations in scripts.
+6. Use profiles to manage multiple Directus instances.
+
+## Decision Tree
+
+### Connect to Directus
+
+```
+How to authenticate?
+  Quick one-off:
+    - Static token: directus-cli <cmd> --url <url> --token <token>
+    - Env vars: DIRECTUS_URL + DIRECTUS_TOKEN
+  Interactive login:
+    - Email/password: directus-cli auth login --email <email> --password <password> --url <url>
+  Non-interactive / CI / agent login:
+    - Pipe password via stdin (no shell history / process list exposure):
+      echo "$PASSWORD" | directus-cli auth login --email <email> --password-stdin --url <url>
+  Persistent (recommended):
+    - Save profile: directus-cli profile add <name> <url> --token <token> --default
+    - Then use: directus-cli <cmd> --profile <name>
+
+Token hygiene:
+  - Access tokens refresh automatically on 401 when the profile has a refresh token (transparent to callers).
+  - Tokens within 60 s of expiry refresh proactively before the request is made.
+  - `auth refresh` reports a structured failure reason (missingProfile / missingRefreshToken / networkError / rejected / unknown) with per-reason actionable messages.
+  - `auth status` emits structured output: auth kind, expiry, account info (id/email/role), classified errors (auth/network/unknown).
+```
+
+Read `references/auth.md` for exact commands.
+
+### Choose the Right Command
+
+```
+What resource to manage?
+  Data:
+    - Collections/fields/relations: collections, fields, relations
+    - Items (CRUD): items list/get/create/update/delete <collection>
+    - Bulk data: bulk export/import <collection>
+  Users & Access:
+    - Users: users list/get/create/update/delete
+    - Roles: roles list/get/create/update/delete
+    - Policies (Directus 11+): policies list/get/create/update/delete
+    - Permissions: permissions list
+  Schema & Config:
+    - Schema migrations: schema snapshot/diff/apply
+    - Settings: settings get/update
+    - Presets: presets list/get/create/update/delete
+  Files:
+    - Upload/download: files upload/download/list
+    - Folders: folders list/get/create/update/delete
+  Extensions:
+    - List installed: extensions list
+    - Enable/disable: extensions toggle <name> --enable/--disable
+    - Search marketplace: extensions search [query]
+    - Show metadata: extensions info <name|uuid|name@version>
+    - Install: extensions install <name>[@version]
+    - Uninstall: extensions uninstall <name>
+    - Reinstall current pinned version: extensions reinstall <name>
+    - Upgrade (non-atomic): extensions upgrade <name>[@version]
+  Automation:
+    - Flows: flows list/get/create/update/delete/trigger
+    - Operations: operations list/get/create/update/delete
+  Analytics:
+    - Dashboards: dashboards list/get/create/update/delete
+    - Panels: panels list/get/create/update/delete
+  Monitoring:
+    - Activity: activity list
+    - Revisions: revisions list
+    - Server: server ping, server info
+```
+
+Read `references/command-reference.md` for the full command table.
+
+## Secrets Handling (Do This By Default)
+
+- Never put tokens directly in command lines that may be logged.
+- Prefer env vars (`DIRECTUS_TOKEN`) or profiles over inline `--token`.
+- Never print tokens into logs, diffs, or chat transcripts.
+
+## Command Discovery
+
+```bash
+directus-cli --help                    # Top-level topics
+directus-cli <topic> --help            # Commands in a topic
+directus-cli <topic> <command> --help  # Flags for a command
+```
+
+## Global Flags
+
+| Flag                | Short | Description                                      |
+| ------------------- | ----- | ------------------------------------------------ |
+| `--format <format>` | `-f`  | Output: `json` (default), `table`, `yaml`        |
+| `--profile <name>`  | `-p`  | Use a saved profile                              |
+| `--url <url>`       |       | Directus instance URL (overrides profile)        |
+| `--token <token>`   | `-t`  | Static access token (overrides profile)          |
+| `--quiet`           | `-q`  | Suppress metadata/wrappers, output raw data only |
+| `--verbose`         | `-v`  | Request/response debug logging                   |
+
+> **Note:** `--yes` (`-y`) is available on destructive commands (delete, schema apply) to skip confirmation prompts. It is not a global flag.
+
+## Key Patterns
+
+```bash
+# Filter items (simple equality, not-equal, or JSON syntax)
+directus-cli items list posts --filter status=published
+directus-cli items list posts --filter '{"date_created":{"_gt":"2024-01-01"}}'
+
+# Sort, paginate, select fields
+directus-cli items list posts --sort -date_created --limit 10 --offset 20 --fields id,title
+
+# Pipe JSON output to jq (default JSON wraps data in {"data": [...]})
+directus-cli users list --format json | jq '.data[].email'
+
+# Use --quiet to get raw data without the wrapper
+directus-cli users list --quiet | jq '.[].email'
+
+# Bulk export/import
+directus-cli bulk export articles --format json --output articles.json
+directus-cli bulk import articles ./data.csv
+```
+
+Read `references/filters-and-output.md` for full filter syntax and output options.
+
+## Common Gotchas
+
+- **JSON output is wrapped:** Default `--format json` returns `{"data": [...], "meta": {...}}`. Use `jq '.data'` to extract the array, or use `--quiet` to get the raw array directly.
+- **Policies vs Roles:** Directus 11+ uses policies for access control. Roles are for grouping users.
+- **Schema apply is destructive:** Applying snapshots can delete data. Always backup first.
+- **Relations require both collections:** Create collections before creating relations between them.
+- **Default output is JSON**, not table. Use `--format table` for human-readable output.
+- **Connection resolution order:** CLI flags > environment variables > saved profile.
+- **Config location:** `~/.config/directus-cli/config.json` (XDG compliant).
+- **`fields list` without `--collection`:** Returns all fields across all collections. Add `--collection <name>` to scope to one collection.
+- **semantic-release edge case:** If a version already exists on npm but the GitHub Release is missing, the release workflow will fail with E403. Fix manually: `gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."`
+- **Extension name lives in `schema.name`:** `extensions list` flattens this for you (as of 0.3.2), but if you parse the raw API response, the human name is under `schema.name`, not top-level `name`. The top-level `name` field is commonly missing; fall back through `schema.name -> name -> id`.
+- **Registry commands require a real name:** `extensions reinstall`/`upgrade`/`info` hit `/extensions/registry/extension/<name>` and reject row UUIDs. Pass the human name (e.g. `directus-extension-computed-values`), not the installed-row PK.
+
+## Release Workflow (for maintainers)
+
+The repo uses semantic-release with the following behavior:
+- **Version determination:** Analyzes commits since last git tag using conventional commits
+- **Publish target:** npm registry + GitHub Releases
+- **No `@semantic-release/git` plugin:** Does NOT commit CHANGELOG.md or package.json version back to main (blocked by branch protection)
+
+### Common release issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| E403 "cannot publish over previously published versions" | Version exists on npm from partial run, but no git tag exists | Manually create git tag + GitHub Release: `git tag vX.Y.Z && git push origin vX.Y.Z && gh release create vX.Y.Z ...` |
+| "Changes must be made through a pull request" | `@semantic-release/git` trying to push commits to protected main | Plugin removed in PR #4, no longer applicable |
+| Wrong version (e.g., 1.0.0 instead of 0.1.0) | Historical `BREAKING CHANGE:` footer in commits | Create `v0.0.0` tag on initial commit to anchor versioning |
+
+## References
+
+- `references/install.md` -- Installation methods
+- `references/auth.md` -- Authentication, profiles, environment variables
+- `references/command-reference.md` -- Full command table with args and flags
+- `references/filters-and-output.md` -- Filter syntax, output formats, sorting, pagination
+- `references/examples.md` -- End-to-end workflow examples
+
+## Session Wrap-Up: Submit Improvements
+
+At the end of every session working with directus-cli, **propose a PR** if any of the following were discovered:
+
+1. **Documentation errors** -- typos, wrong flags, broken examples, outdated syntax
+2. **Missing capabilities** -- commands that don't exist but should (check if SDK supports it)
+3. **CLI bugs** -- crashes, wrong output format, auth issues, flag parsing problems
+4. **UX friction** -- confusing error messages, missing `--yes` on destructive commands, inconsistent flag names
+5. **SDK/CLI gaps** -- Directus SDK supports a feature but CLI doesn't expose it
+
+### How to submit
+
+```bash
+# 1. Check if issue already exists
+gh issue list --search "<keyword>"
+
+# 2. Create a branch with conventional commit prefix
+#    fix: for bugs/docs    feat: for new commands    ci: for workflow
+
+# 3. Make minimal changes (one concern per PR)
+
+# 4. Run full check: pnpm install && pnpm build && pnpm lint && pnpm test
+
+# 5. Push and create PR with clear description of the problem + fix
+```
+
+### PR scope rules (from repo conventions)
+
+- **Separate PRs by scope:** `fix:` PRs for bugs, `feat:` PRs for features. Don't combine.
+- **No global formatting:** Run `eslint --fix` only on changed files. Never `pnpm format:fix` (touches 100+ files).
+- **CI must pass:** build → lint → test (no prettier check in CI).
+- **ESLint wins over Prettier:** The oclif stylistic config conflicts with prettier. Follow eslint.
+
+### Quick gotcha reference (add to skill if discovered)
+
+If you hit a new gotcha, append to the **Common Gotchas** section above with the format:
+
+```
+- **Short description:** Detailed explanation with workaround or fix.
+```
+
+This keeps the skill file auto-evolving with real usage patterns.

--- a/skill/references/auth.md
+++ b/skill/references/auth.md
@@ -1,0 +1,116 @@
+# Authentication
+
+## Connection Resolution Order
+
+CLI flags > environment variables > saved profile (default profile if none specified).
+
+## Methods
+
+### 1. Email/Password Login
+
+```bash
+directus-cli auth login --email <email> --password <password>
+# Or with explicit URL (overrides profile)
+directus-cli auth login --email <email> --password <password> --url <url>
+```
+
+Stores access and refresh tokens in the active profile. Tokens auto-refresh on expiry
+(see **Token Lifecycle** below).
+
+#### Non-interactive login (`--password-stdin`)
+
+For CI, agent workflows, and any context where the password must not appear in shell
+history, process listings, or command transcripts, pipe it on stdin:
+
+```bash
+echo "$DIRECTUS_PASSWORD" | directus-cli auth login --email admin@example.com --password-stdin
+cat ~/.secrets/directus-admin | directus-cli auth login --email admin@example.com --password-stdin --profile prod
+```
+
+- Mutually exclusive with `--password`.
+- Errors with a clear message (instead of hanging on EOF) when stdin is a TTY.
+
+### 2. Static Token
+
+```bash
+# Via flag
+directus-cli <command> --url <url> --token <token>
+
+# Via environment variables
+export DIRECTUS_URL=https://your-directus.com
+export DIRECTUS_TOKEN=your-static-token
+```
+
+### 3. Profiles (Recommended for Multi-Instance)
+
+```bash
+# Add a profile with static token
+directus-cli profile add production https://api.example.com --token $PROD_TOKEN --default
+
+# Add a profile and login with credentials
+directus-cli profile add dev http://localhost:8055
+directus-cli auth login --email admin@example.com --password secret --profile dev
+
+# List profiles
+directus-cli profile list
+
+# Switch default profile
+directus-cli profile use production
+
+# Use a specific profile per command
+directus-cli users list --profile dev
+
+# Remove a profile
+directus-cli profile remove old-instance
+```
+
+## Environment Variables
+
+| Variable            | Description                   |
+| ------------------- | ----------------------------- |
+| `DIRECTUS_URL`      | Default Directus instance URL |
+| `DIRECTUS_TOKEN`    | Default static access token   |
+| `DIRECTUS_EMAIL`    | Default login email           |
+| `DIRECTUS_PASSWORD` | Default login password        |
+| `DIRECTUS_PROFILE`  | Default profile name          |
+
+## Session Management
+
+```bash
+# Check current auth status (structured output)
+directus-cli auth status
+directus-cli auth status --profile prod
+
+# Manually refresh tokens
+directus-cli auth refresh
+directus-cli auth refresh --profile prod
+
+# Logout (invalidate session)
+directus-cli auth logout
+```
+
+## Token Lifecycle
+
+- **Transparent refresh on 401**: every SDK-backed command automatically refreshes
+  the access token and retries the request once when a 401 is returned, provided the
+  profile has a stored refresh token and the token is not a static PAT. No manual
+  `auth refresh` required under normal operation.
+- **Proactive refresh window**: tokens within 60 seconds of expiry are refreshed
+  before the request is sent, protecting long-running commands from mid-flight
+  expiries.
+- **`auth refresh` failure reasons** (surfaced with per-reason actionable messages):
+  - `missingProfile` — the named profile does not exist.
+  - `missingRefreshToken` — no refresh token stored; log in again.
+  - `networkError` — the server was unreachable.
+  - `rejected` — the server rejected the refresh token (expired / revoked /
+    password changed / logged out elsewhere).
+  - `unknown` — any other error; details included in the message.
+- **`auth status` output** includes: auth kind (`static` vs `oauth`), expiry,
+  account info (id / email / role), and classified errors (`auth` / `network` /
+  `unknown`) so scripts can distinguish "server unreachable" from "token rejected".
+
+## Config File Location
+
+Profiles are stored in `~/.config/directus-cli/config.json` (XDG_CONFIG_HOME compliant).
+On POSIX systems the file is written with `0600` mode and the parent directory with
+`0700` mode. No-op on Windows.

--- a/skill/references/command-reference.md
+++ b/skill/references/command-reference.md
@@ -1,0 +1,201 @@
+# Command Reference
+
+## Authentication & Profiles
+
+| Command                    | Args                                                              | Description                   |
+| -------------------------- | ----------------------------------------------------------------- | ----------------------------- |
+| `auth login`               | `--email`, `--password` \| `--password-stdin`, `--url`, `--profile` | Authenticate with Directus    |
+| `auth logout`              |                                                                   | Logout and invalidate session |
+| `auth refresh`             | `--profile`                                                       | Refresh access token (reports a structured reason on failure: `missingProfile`, `missingRefreshToken`, `networkError`, `rejected`, `unknown`) |
+| `auth status`              | `--profile`                                                       | Structured status: auth kind (`static`/`oauth`), expiry, account info, classified errors (`auth`/`network`/`unknown`) |
+| `profile add <name> <url>` | `--token`, `--default`                                            | Add a connection profile      |
+| `profile list`             |                                                                   | List saved profiles           |
+| `profile use <name>`       |                                                                   | Set default profile           |
+| `profile remove <name>`    |                                                                   | Remove a profile              |
+
+**Non-interactive login**: prefer `--password-stdin` in CI / agent contexts to keep passwords out of shell history and process lists:
+
+```bash
+echo "$DIRECTUS_PASSWORD" | directus-cli auth login --email admin@example.com --password-stdin
+```
+
+`--password-stdin` is mutually exclusive with `--password` and errors out if stdin is a TTY (so it never hangs waiting for EOF).
+
+**Transparent refresh**: every SDK-backed command automatically refreshes the access token on a 401 and retries once when the profile has a stored refresh token. Tokens within 60 s of expiry are refreshed proactively before the request is made.
+
+## Collections & Fields
+
+| Command                              | Args                   | Description                                    |
+| ------------------------------------ | ---------------------- | ---------------------------------------------- |
+| `collections list`                   | `--names-only`         | List all collections (full objects by default) |
+| `collections get <name>`             |                        | Get collection details                         |
+| `collections create <name>`          | `--note`               | Create a collection                            |
+| `collections update <name>`          | `--note`               | Update a collection                            |
+| `collections delete <name>`          | `--yes`                | Delete a collection                            |
+| `fields list`                        | `--collection`         | List fields (all or by collection)             |
+| `fields get <collection> <field>`    |                        | Get field details                              |
+| `fields create <collection> <field>` | `--type`, `--required` | Create a field                                 |
+| `fields update <collection> <field>` | `--type`, `--required` | Update a field                                 |
+| `fields delete <collection> <field>` | `--yes`                | Delete a field                                 |
+
+### Field Types
+
+Common `--type` values: `string`, `text`, `integer`, `decimal`, `float`, `boolean`, `date`, `datetime`, `timestamp`, `json`, `uuid`, `csv`, `hash`, `bigInteger`.
+
+## Items
+
+| Command                                 | Args                                                                | Description                              |
+| --------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------- |
+| `items list <collection>`               | `--filter`, `--sort`, `--limit`, `--offset`, `--fields`, `--search` | List items                               |
+| `items get <collection> <id>`           | `--fields`                                                          | Get a single item                        |
+| `items create <collection> <data>`      | `--file`                                                            | Create an item (inline JSON or `--file`) |
+| `items update <collection> <id> <data>` | `--file`                                                            | Update an item                           |
+| `items delete <collection> <id>`        | `--yes`                                                             | Delete an item                           |
+
+## Relations
+
+| Command                                 | Args                             | Description          |
+| --------------------------------------- | -------------------------------- | -------------------- |
+| `relations list`                        | `--collection`                   | List relations       |
+| `relations get <collection> <field>`    |                                  | Get relation details |
+| `relations create <collection> <field>` | `--related-collection`, `--type` | Create a relation    |
+| `relations update <collection> <field>` |                                  | Update a relation    |
+| `relations delete <collection> <field>` | `--yes`                          | Delete a relation    |
+
+## Extensions
+
+Installed-extension management:
+
+| Command                    | Args                                | Description                    |
+| -------------------------- | ----------------------------------- | ------------------------------ |
+| `extensions list`          | `--type`, `--enabled`               | List installed extensions      |
+| `extensions toggle <name>` | `--enable`, `--disable`, `--bundle` | Enable or disable an extension |
+
+Marketplace registry management (admin-only; hits `/extensions/registry/*`):
+
+| Command                        | Args                                                  | Description                                                |
+| ------------------------------ | ----------------------------------------------------- | ---------------------------------------------------------- |
+| `extensions search [query]`    | `--limit`, `--offset`, `--type`, `--sandbox`          | Search the marketplace registry                            |
+| `extensions info <ext>`        |                                                       | Show metadata + version list (name, UUID, or `name@ver`)   |
+| `extensions install <ext>`     | `<ext>` may be `name`, `uuid`, or `name@version`      | Install latest safe non-prerelease version (or pinned)     |
+| `extensions uninstall <ext>`   | `--yes`                                               | Uninstall a registry-sourced extension                     |
+| `extensions reinstall <ext>`   |                                                       | Re-download the currently pinned version                   |
+| `extensions upgrade <ext>`     | `--yes`, optional `@version` suffix                   | Uninstall + reinstall (**non-atomic**; surfaces retry hint on partial failure) |
+
+Notes:
+
+- `install` / `upgrade` validate the requested version against the registry before the slow install step and reject `unsafe: true` versions up front.
+- `uninstall` only targets extensions with `source === 'registry'` (server-enforced).
+- `upgrade` is explicitly non-atomic: the extension is briefly unavailable between uninstall and install steps.
+- All registry endpoints require an admin token; non-admin tokens surface as a standard `DirectusCliError`.
+
+## Users & Access Control
+
+| Command                  | Args                                                  | Description                  |
+| ------------------------ | ----------------------------------------------------- | ---------------------------- |
+| `users list`             | `--filter`, `--sort`, `--limit`, `--fields`           | List users                   |
+| `users get <id>`         |                                                       | Get user details             |
+| `users create <email>`   | `--password`, `--role`, `--first-name`, `--last-name` | Create a user                |
+| `users update <id>`      | `--role`, `--email`, `--first-name`, `--last-name`    | Update a user                |
+| `users delete <id>`      | `--yes`                                               | Delete a user                |
+| `roles list`             |                                                       | List roles                   |
+| `roles get <id>`         |                                                       | Get role details             |
+| `roles create <name>`    | `--description`, `--admin-access`                     | Create a role                |
+| `roles update <id>`      | `--name`, `--description`                             | Update a role                |
+| `roles delete <id>`      | `--yes`                                               | Delete a role                |
+| `policies list`          |                                                       | List policies (Directus 11+) |
+| `policies get <id>`      |                                                       | Get policy details           |
+| `policies create <name>` | `--description`, `--admin-access`                     | Create a policy              |
+| `policies update <id>`   | `--name`, `--description`                             | Update a policy              |
+| `policies delete <id>`   | `--yes`                                               | Delete a policy              |
+| `permissions list`       | `--filter`                                            | List permissions             |
+
+## Files & Folders
+
+| Command                 | Args                                        | Description        |
+| ----------------------- | ------------------------------------------- | ------------------ |
+| `files list`            | `--folder`, `--filter`, `--sort`, `--limit` | List files         |
+| `files upload <path>`   | `--folder`, `--title`, `--description`      | Upload a file      |
+| `files download <id>`   | `--output`                                  | Download a file    |
+| `folders list`          |                                             | List folders       |
+| `folders get <id>`      |                                             | Get folder details |
+| `folders create <name>` | `--parent`                                  | Create a folder    |
+| `folders update <id>`   | `--name`, `--parent`                        | Update a folder    |
+| `folders delete <id>`   | `--yes`                                     | Delete a folder    |
+
+## Flows & Operations (Automation)
+
+| Command                           | Args                                                  | Description           |
+| --------------------------------- | ----------------------------------------------------- | --------------------- |
+| `flows list`                      |                                                       | List flows            |
+| `flows get <id>`                  |                                                       | Get flow details      |
+| `flows create <name>`             | `--status`, `--trigger`, `--description`              | Create a flow         |
+| `flows update <id>`               | `--name`, `--status`                                  | Update a flow         |
+| `flows delete <id>`               | `--yes`                                               | Delete a flow         |
+| `flows trigger <id>`              | `--data`                                              | Trigger a manual flow |
+| `operations list`                 | `--flow`                                              | List operations       |
+| `operations get <id>`             |                                                       | Get operation details |
+| `operations create <flow> <type>` | `--name`, `--options`, `--position-x`, `--position-y` | Create an operation   |
+| `operations update <id>`          | `--name`, `--options`                                 | Update an operation   |
+| `operations delete <id>`          | `--yes`                                               | Delete an operation   |
+
+## Schema Management
+
+| Command               | Args                   | Description                                   |
+| --------------------- | ---------------------- | --------------------------------------------- |
+| `schema snapshot`     | `--output`, `--format` | Export schema to file (JSON or YAML)          |
+| `schema diff <file>`  |                        | Compare schema snapshot with current instance |
+| `schema apply <file>` | `--yes`                | Apply schema from snapshot file               |
+
+## Dashboards & Panels (Analytics)
+
+| Command                                   | Args                                                               | Description           |
+| ----------------------------------------- | ------------------------------------------------------------------ | --------------------- |
+| `dashboards list`                         |                                                                    | List dashboards       |
+| `dashboards get <id>`                     |                                                                    | Get dashboard details |
+| `dashboards create <name>`                | `--note`, `--icon`, `--color`                                      | Create a dashboard    |
+| `dashboards update <id>`                  | `--name`, `--note`                                                 | Update a dashboard    |
+| `dashboards delete <id>`                  | `--yes`                                                            | Delete a dashboard    |
+| `panels list`                             | `--dashboard`                                                      | List panels           |
+| `panels get <id>`                         |                                                                    | Get panel details     |
+| `panels create <dashboard> <name> <type>` | `--options`, `--position-x`, `--position-y`, `--width`, `--height` | Create a panel        |
+| `panels update <id>`                      | `--name`, `--options`                                              | Update a panel        |
+| `panels delete <id>`                      | `--yes`                                                            | Delete a panel        |
+
+## Settings & Presets
+
+| Command                       | Args                                         | Description                  |
+| ----------------------------- | -------------------------------------------- | ---------------------------- |
+| `settings get`                |                                              | Get global instance settings |
+| `settings update`             | `--data`                                     | Update instance settings     |
+| `presets list`                |                                              | List presets/bookmarks       |
+| `presets get <id>`            |                                              | Get a preset                 |
+| `presets create <collection>` | `--name`, `--layout`, `--filter`, `--fields` | Create a preset              |
+| `presets update <id>`         | `--name`, `--layout`                         | Update a preset              |
+| `presets delete <id>`         | `--yes`                                      | Delete a preset              |
+
+## Comments
+
+| Command                | Args                                  | Description      |
+| ---------------------- | ------------------------------------- | ---------------- |
+| `comments list`        | `--filter`, `--sort`, `--limit`       | List comments    |
+| `comments get <id>`    |                                       | Get a comment    |
+| `comments create`      | `--collection`, `--item`, `--comment` | Create a comment |
+| `comments update <id>` | `--comment`                           | Update a comment |
+| `comments delete <id>` | `--yes`                               | Delete a comment |
+
+## Bulk Operations
+
+| Command                           | Args                                                                | Description                                  |
+| --------------------------------- | ------------------------------------------------------------------- | -------------------------------------------- |
+| `bulk export <collection>`        | `--format`, `--output`, `--filter`, `--fields`, `--sort`, `--limit` | Export data to file                          |
+| `bulk import <collection> <file>` |                                                                     | Import data from file (JSON, CSV, XML, YAML) |
+
+## Server & Activity
+
+| Command          | Args                            | Description               |
+| ---------------- | ------------------------------- | ------------------------- |
+| `server ping`    |                                 | Check server connectivity |
+| `server info`    |                                 | Get server information    |
+| `activity list`  | `--filter`, `--sort`, `--limit` | List activity log entries |
+| `revisions list` | `--filter`, `--sort`, `--limit` | List revisions            |

--- a/skill/references/examples.md
+++ b/skill/references/examples.md
@@ -1,0 +1,148 @@
+# End-to-End Workflow Examples
+
+## Set Up a Blog
+
+```bash
+# Authenticate
+directus-cli auth login --url https://your-directus.com --email admin@example.com --password secret
+directus-cli profile add blog https://your-directus.com --default
+
+# Create collections
+directus-cli collections create posts --note "Blog posts"
+directus-cli collections create categories --note "Post categories"
+
+# Add fields to posts
+directus-cli fields create posts title --type string --required
+directus-cli fields create posts slug --type string --required
+directus-cli fields create posts content --type text
+directus-cli fields create posts status --type string
+directus-cli fields create posts published_date --type date
+directus-cli fields create posts featured_image --type uuid
+
+# Add fields to categories
+directus-cli fields create categories name --type string --required
+directus-cli fields create categories slug --type string --required
+
+# Create a relation (posts -> categories)
+directus-cli fields create posts category --type uuid
+directus-cli relations create posts category --related-collection categories
+
+# Create sample data
+directus-cli items create categories '{"name":"Tech","slug":"tech"}'
+directus-cli items create posts '{
+  "title": "Hello World",
+  "slug": "hello-world",
+  "content": "My first blog post",
+  "status": "published",
+  "published_date": "2024-01-01"
+}'
+
+# Query published posts
+directus-cli items list posts --filter status=published --sort -published_date --fields id,title,slug,published_date
+```
+
+## Multi-Environment Schema Migration
+
+```bash
+# Set up profiles
+directus-cli profile add dev http://localhost:8055 --token $DEV_TOKEN
+directus-cli profile add staging https://staging.example.com --token $STAGING_TOKEN
+directus-cli profile add prod https://api.example.com --token $PROD_TOKEN
+
+# Export schema from dev
+directus-cli schema snapshot --output ./schema.yaml --profile dev
+
+# Review changes against staging
+directus-cli schema diff ./schema.yaml --profile staging
+
+# Apply to staging (with confirmation)
+directus-cli schema apply ./schema.yaml --profile staging --yes
+
+# Apply to production
+directus-cli schema apply ./schema.yaml --profile prod --yes
+```
+
+## Bulk Data Export and Import
+
+```bash
+# Export all published articles to JSON
+directus-cli bulk export articles --format json --output ./articles.json --filter '{"status":{"_eq":"published"}}'
+
+# Export users to CSV
+directus-cli bulk export directus_users --format csv --output ./users.csv
+
+# Import data from CSV into a different instance
+directus-cli bulk import articles ./articles.json --profile staging
+
+# Import from CSV
+directus-cli bulk import contacts ./contacts.csv --profile prod
+```
+
+## User and Access Control Setup
+
+```bash
+# Create a role
+directus-cli roles create "Content Editor" --description "Can edit content"
+
+# Create a policy (Directus 11+)
+directus-cli policies create "Blog Editor Access" --description "Edit blog posts"
+
+# Create a user with the role
+directus-cli users create editor@example.com \
+  --password "temp-password" \
+  --role <role-id> \
+  --first-name "Jane" \
+  --last-name "Editor"
+
+# List users by role
+directus-cli users list --filter role=<role-id> --fields id,email,first_name
+```
+
+## File Management
+
+```bash
+# Create a folder
+directus-cli folders create "Blog Images"
+
+# Upload files to the folder
+directus-cli files upload ./hero.png --folder <folder-id> --title "Hero Image"
+directus-cli files upload ./thumb.jpg --folder <folder-id> --title "Thumbnail"
+
+# List files in folder
+directus-cli files list --folder <folder-id>
+
+# Download a file
+directus-cli files download <file-id> --output ./downloaded-image.png
+```
+
+## Automation: Trigger a Flow
+
+```bash
+# List available flows
+directus-cli flows list --fields id,name,status
+
+# Trigger a manual flow with data
+directus-cli flows trigger <flow-id> --data '{"message":"deploy triggered"}'
+```
+
+## CI/CD Script Example
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Uses environment variables: DIRECTUS_URL, DIRECTUS_TOKEN
+
+# Verify connectivity
+directus-cli server ping
+
+# Apply schema migration
+directus-cli schema apply ./schema.yaml --yes
+
+# Import seed data
+directus-cli bulk import articles ./seed-data.json
+
+# Verify
+directus-cli items list articles --limit 5 -f table
+echo "Deployment complete."
+```

--- a/skill/references/filters-and-output.md
+++ b/skill/references/filters-and-output.md
@@ -1,0 +1,131 @@
+# Filters, Output, and Pagination
+
+## Output Formats
+
+Add `--format <format>` (`-f`) to any command:
+
+| Format  | Description           |
+| ------- | --------------------- |
+| `json`  | JSON output (default) |
+| `table` | Human-readable table  |
+| `yaml`  | YAML output           |
+
+```bash
+# JSON (default) — output is wrapped: {"data": [...], "meta": {...}}
+directus-cli users list
+
+# Table for human reading
+directus-cli users list -f table
+
+# YAML
+directus-cli users list -f yaml
+
+# Pipe JSON to jq (extract from .data wrapper)
+directus-cli users list | jq '.data[].email'
+
+# Use --quiet for raw data without the wrapper (ideal for piping)
+directus-cli users list --quiet | jq '.[].email'
+```
+
+## Filter Syntax
+
+### Simple Equality
+
+```bash
+directus-cli items list posts --filter status=published
+```
+
+### Not Equal
+
+```bash
+directus-cli items list posts --filter 'status!=draft'
+```
+
+### Multiple Filters (AND Logic)
+
+```bash
+directus-cli items list posts --filter status=published --filter featured=true
+```
+
+### JSON Filter (Complex Queries)
+
+Use Directus filter operators in JSON:
+
+```bash
+# Greater than
+directus-cli items list posts --filter '{"date_created":{"_gt":"2024-01-01"}}'
+
+# Contains
+directus-cli items list posts --filter '{"title":{"_contains":"hello"}}'
+
+# In list
+directus-cli items list posts --filter '{"status":{"_in":["published","review"]}}'
+
+# Null check
+directus-cli items list posts --filter '{"published_date":{"_nnull":true}}'
+
+# Nested / relational
+directus-cli items list posts --filter '{"author":{"email":{"_eq":"admin@example.com"}}}'
+```
+
+### Common Directus Filter Operators
+
+| Operator       | Description           |
+| -------------- | --------------------- |
+| `_eq`          | Equal                 |
+| `_neq`         | Not equal             |
+| `_gt`          | Greater than          |
+| `_gte`         | Greater than or equal |
+| `_lt`          | Less than             |
+| `_lte`         | Less than or equal    |
+| `_in`          | In array              |
+| `_nin`         | Not in array          |
+| `_contains`    | Contains substring    |
+| `_ncontains`   | Does not contain      |
+| `_starts_with` | Starts with           |
+| `_ends_with`   | Ends with             |
+| `_null`        | Is null               |
+| `_nnull`       | Is not null           |
+| `_between`     | Between two values    |
+| `_empty`       | Is empty              |
+| `_nempty`      | Is not empty          |
+
+## Sorting
+
+```bash
+# Ascending (default)
+directus-cli items list posts --sort date_created
+
+# Descending (prefix with -)
+directus-cli items list posts --sort -date_created
+
+# Multiple sort fields
+directus-cli items list posts --sort status --sort -date_created
+```
+
+## Pagination
+
+```bash
+# Limit results
+directus-cli items list posts --limit 10
+
+# Offset (skip first N)
+directus-cli items list posts --limit 10 --offset 20
+```
+
+## Field Selection
+
+```bash
+# Select specific fields
+directus-cli users list --fields id,email,first_name,last_name
+
+# Relational fields
+directus-cli items list posts --fields id,title,author.email
+```
+
+## Search
+
+```bash
+# Full-text search
+directus-cli items list posts --search "hello world"
+```

--- a/skill/references/install.md
+++ b/skill/references/install.md
@@ -1,0 +1,44 @@
+# Installation
+
+## Global Installation (Recommended)
+
+```bash
+npm install -g @face-to-face-it/directus-cli
+# or
+pnpm add -g @face-to-face-it/directus-cli
+```
+
+## Local Project Installation
+
+```bash
+npm install --save-dev @face-to-face-it/directus-cli
+# or
+pnpm add -D @face-to-face-it/directus-cli
+```
+
+## Using npx (No Installation)
+
+```bash
+npx @face-to-face-it/directus-cli <command>
+```
+
+## Verify Installation
+
+```bash
+directus-cli --version
+directus-cli --help
+```
+
+## Requirements
+
+- Node.js >= 20
+
+## Building from Source
+
+```bash
+git clone https://github.com/Face-to-Face-IT/directus-cli.git
+cd directus-cli
+pnpm install
+pnpm build
+./bin/dev.js --help
+```


### PR DESCRIPTION
## Summary
- Commits the agent skill (`SKILL.md` + `references/`) under `skill/` at the repo root so it lives alongside the code instead of only in `~/.agents/skills/`.
- Adds two gotchas reflecting the #10 / #11 fixes shipped in 0.3.2:
  - Extension human name lives in `schema.name`; fall back through `schema.name -> name -> id` when parsing raw API responses.
  - `extensions reinstall` / `upgrade` / `info` require the real registry name, not a row UUID.
- `skill/README.md` documents how to sync the files into `~/.agents/skills/directus-cli/` after merging.

## Test plan
- Pre-commit hook ran full test suite: 98/98 passing.
- Docs-only change, no source touched.