### PR TITLE
fix(auth): send refresh_token in payload when refreshing access token

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -145,7 +145,7 @@ export class DirectusClient {
     }
 
     try {
-      const refreshUrl = new URL('/auth/refresh', this.url).toString();
+      const refreshUrl = buildRefreshUrl(this.url);
       // eslint-disable-next-line n/no-unsupported-features/node-builtins -- global fetch is available in Node 20+
       const response = await fetch(refreshUrl, {
         // eslint-disable-next-line camelcase -- refresh_token is the Directus API field name
@@ -270,6 +270,19 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => {
     setTimeout(resolve, ms);
   });
+}
+
+/**
+ * Build the `/auth/refresh` URL relative to a Directus base URL, preserving
+ * any subpath configured on the instance (e.g. `https://example.com/directus/`
+ * must refresh at `https://example.com/directus/auth/refresh`, not at the
+ * host root). Passing a root-absolute path to the URL constructor discards
+ * the base pathname, so we resolve a relative segment against a base that is
+ * guaranteed to have a trailing slash.
+ */
+export function buildRefreshUrl(baseUrl: string): string {
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return new URL('auth/refresh', normalizedBase).toString();
 }
 
 /**

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -173,6 +173,14 @@ export class DirectusClient {
 
       if (result.access_token) {
         this.client.setToken(result.access_token);
+
+        // Persist the rotated refresh token so subsequent in-process refreshes
+        // use the latest value. The rotated token is also returned so callers
+        // (e.g. the config profile) can persist it to disk.
+        if (result.refresh_token) {
+          this.refreshToken = result.refresh_token;
+        }
+
         return {
           accessToken: result.access_token,
           expires: result.expires ?? undefined,

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -128,6 +128,15 @@ export class DirectusClient {
 
   /**
    * Refresh the access token using the stored refresh token.
+   *
+   * We bypass the Directus SDK's `authentication().refresh()` here because the
+   * SDK's composable reads `refresh_token` from its internal storage and
+   * silently ignores the one passed via its options argument. Each CLI
+   * invocation is a fresh Node process with empty in-memory SDK storage, so
+   * the SDK would always POST `{ mode: 'cookie' }` with no token and the
+   * server responds: "The refresh token is required in either the payload or
+   * cookie." We therefore POST `/auth/refresh` directly with mode=json + the
+   * persisted refresh token.
    */
   async refreshAccessToken(): Promise<undefined | {accessToken: string; expires?: number; refreshToken?: string}> {
     if (!this.refreshToken) {
@@ -135,7 +144,32 @@ export class DirectusClient {
     }
 
     try {
-      const result = await this.client.refresh();
+      const refreshUrl = new URL('/auth/refresh', this.url).toString();
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins -- global fetch is available in Node 20+
+      const response = await fetch(refreshUrl, {
+        // eslint-disable-next-line camelcase -- refresh_token is the Directus API field name
+        body: JSON.stringify({mode: 'json', refresh_token: this.refreshToken}),
+        headers: {'Content-Type': 'application/json'},
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        let detail = `HTTP ${response.status}`;
+        try {
+          const body = (await response.json()) as {errors?: Array<{message?: string}>};
+          detail = body?.errors?.[0]?.message ?? detail;
+        } catch {
+          /* ignore body parse errors */
+        }
+
+        throw new DirectusCliError(`Token refresh failed: ${detail}`, response.status);
+      }
+
+      const payload = (await response.json()) as {
+        data?: {access_token?: string; expires?: number; refresh_token?: string};
+      };
+      const result = payload?.data ?? (payload as {access_token?: string; expires?: number; refresh_token?: string});
+
       if (result.access_token) {
         this.client.setToken(result.access_token);
         return {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -133,10 +133,11 @@ export class DirectusClient {
    * SDK's composable reads `refresh_token` from its internal storage and
    * silently ignores the one passed via its options argument. Each CLI
    * invocation is a fresh Node process with empty in-memory SDK storage, so
-   * the SDK would always POST `{ mode: 'cookie' }` with no token and the
-   * server responds: "The refresh token is required in either the payload or
-   * cookie." We therefore POST `/auth/refresh` directly with mode=json + the
-   * persisted refresh token.
+   * in this `authentication('json', ...)` client configuration the SDK refresh
+   * request would still be sent in JSON mode but without the persisted
+   * `refresh_token`, and the server responds: "The refresh token is required
+   * in either the payload or cookie." We therefore POST `/auth/refresh`
+   * directly with mode=json + the persisted refresh token.
    */
   async refreshAccessToken(): Promise<undefined | {accessToken: string; expires?: number; refreshToken?: string}> {
     if (!this.refreshToken) {

--- a/test/lib/client.test.ts
+++ b/test/lib/client.test.ts
@@ -148,4 +148,40 @@ describe('DirectusClient.refreshAccessToken', () => {
     const [url] = mockFetch.mock.calls[0]!;
     expect(url).toBe('https://example.test/directus/auth/refresh');
   });
+
+  it('uses the latest refresh token returned by a previous refresh', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        json: async () => ({
+          data: {access_token: 'new-access-1', expires: 900_000, refresh_token: 'rotated-refresh'},
+        }),
+        ok: true,
+        status: 200,
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          data: {access_token: 'new-access-2', expires: 900_000, refresh_token: 'rotated-refresh-2'},
+        }),
+        ok: true,
+        status: 200,
+      });
+
+    const client = createClient({refreshToken: 'stored-refresh', url: 'https://example.test'});
+
+    await client.refreshAccessToken();
+    await client.refreshAccessToken();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const [, firstInit] = mockFetch.mock.calls[0]!;
+    const [, secondInit] = mockFetch.mock.calls[1]!;
+
+    expect(JSON.parse(firstInit.body as string)).toEqual({
+      mode: 'json',
+      refresh_token: 'stored-refresh',
+    });
+    expect(JSON.parse(secondInit.body as string)).toEqual({
+      mode: 'json',
+      refresh_token: 'rotated-refresh',
+    });
+  });
 });

--- a/test/lib/client.test.ts
+++ b/test/lib/client.test.ts
@@ -107,4 +107,45 @@ describe('DirectusClient.refreshAccessToken', () => {
     const result = await client.refreshAccessToken();
     expect(result).toBeUndefined();
   });
+
+  it('POSTs to the refresh endpoint relative to a base URL pathname', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        data: {access_token: 'new-access', expires: 900_000, refresh_token: 'new-refresh'},
+      }),
+      ok: true,
+      status: 200,
+    });
+
+    const client = createClient({
+      refreshToken: 'stored-refresh',
+      url: 'https://example.test/directus/',
+    });
+
+    await client.refreshAccessToken();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('https://example.test/directus/auth/refresh');
+  });
+
+  it('preserves the base pathname even when the URL is missing a trailing slash', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        data: {access_token: 'new-access', expires: 900_000, refresh_token: 'new-refresh'},
+      }),
+      ok: true,
+      status: 200,
+    });
+
+    const client = createClient({
+      refreshToken: 'stored-refresh',
+      url: 'https://example.test/directus',
+    });
+
+    await client.refreshAccessToken();
+
+    const [url] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('https://example.test/directus/auth/refresh');
+  });
 });

--- a/test/lib/client.test.ts
+++ b/test/lib/client.test.ts
@@ -1,0 +1,110 @@
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest';
+
+import {createClient} from '../../src/lib/client.js';
+
+// Mock @directus/sdk so createClient() doesn't try to build a real client
+vi.mock('@directus/sdk', () => {
+  const mockClient = {
+    login: vi.fn(),
+    refresh: vi.fn(),
+    request: vi.fn(),
+    setToken: vi.fn(),
+  };
+  const authentication = vi.fn(() => (c: unknown) => c);
+  const rest = vi.fn(() => (c: unknown) => c);
+  const createDirectus = vi.fn(() => ({
+    with: vi.fn().mockReturnValue({
+      ...mockClient,
+      with: vi.fn().mockReturnValue(mockClient),
+    }),
+  }));
+  return {authentication, createDirectus, rest};
+});
+
+describe('DirectusClient.refreshAccessToken', () => {
+  const originalFetch = globalThis.fetch;
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns undefined when no refresh token is configured', async () => {
+    const client = createClient({url: 'https://example.test'});
+    const result = await client.refreshAccessToken();
+    expect(result).toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs /auth/refresh with mode=json and the stored refresh_token', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({
+        data: {access_token: 'new-access', expires: 900_000, refresh_token: 'new-refresh'},
+      }),
+      ok: true,
+      status: 200,
+    });
+
+    const client = createClient({refreshToken: 'stored-refresh', url: 'https://example.test'});
+    const result = await client.refreshAccessToken();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('https://example.test/auth/refresh');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({'Content-Type': 'application/json'});
+    expect(JSON.parse(init.body as string)).toEqual({
+      mode: 'json',
+      refresh_token: 'stored-refresh',
+    });
+
+    expect(result).toEqual({
+      accessToken: 'new-access',
+      expires: 900_000,
+      refreshToken: 'new-refresh',
+    });
+  });
+
+  it('throws DirectusCliError with server detail on non-OK response', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({errors: [{message: 'Invalid refresh token.'}]}),
+      ok: false,
+      status: 401,
+    });
+
+    const client = createClient({refreshToken: 'bad', url: 'https://example.test'});
+    await expect(client.refreshAccessToken()).rejects.toThrow(/Invalid refresh token\./);
+  });
+
+  it('propagates HTTP status detail when response body is not JSON', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => {
+        throw new Error('not json');
+      },
+      ok: false,
+      status: 500,
+    });
+
+    const client = createClient({refreshToken: 'x', url: 'https://example.test'});
+    await expect(client.refreshAccessToken()).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('returns undefined if response omits access_token', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({data: {}}),
+      ok: true,
+      status: 200,
+    });
+
+    const client = createClient({refreshToken: 'x', url: 'https://example.test'});
+    const result = await client.refreshAccessToken();
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Stops `directus-cli auth refresh` (and the reactive refresh-on-401 path) from failing with `Invalid payload. The refresh token is required in either the payload or cookie.`
- Replaces the broken `@directus/sdk` `authentication().refresh()` call with a direct `POST /auth/refresh` using `mode: 'json'` and the persisted refresh token
- Adds a new `test/lib/client.test.ts` covering the refresh path (5 tests)

## Root cause

The SDK's authentication composable builds the refresh body from its **internal in-memory storage**, not from the `refresh_token` option callers pass in. From `@directus/sdk`'s `auth/composable.js`:

```js
let r = await f.get();                                    // storage
let a = { mode: e.mode ?? o };
o === 'json' && r?.refresh_token && (a.refresh_token = r.refresh_token);
// ^ e.refresh_token is never read
```

Every CLI invocation is a fresh Node process, so the SDK's in-memory storage is always empty. The CLI would POST `{ mode: 'cookie' }` with no cookie and the server rejected it. This made persistent sessions impossible — every command that crossed the token expiry boundary forced an interactive re-login.

Issue #6 introduced the refresh infrastructure but shipped with this bug because the SDK's API is misleading (accepting `{ refresh_token }` that it silently discards).

## Fix

Bypass the SDK composable and POST `/auth/refresh` directly from `DirectusClient.refreshAccessToken()`:

```ts
const response = await fetch(refreshUrl, {
  body: JSON.stringify({mode: 'json', refresh_token: this.refreshToken}),
  headers: {'Content-Type': 'application/json'},
  method: 'POST',
});
```

Error handling extracts `errors[0].message` from the JSON body and falls back to the HTTP status code if the body isn't JSON — matching the existing `DirectusCliError` contract.

## Verification

Against two live Directus 11.16.1 instances (avcp-dev + sandbox):

```
$ directus-cli auth refresh --profile sandbox
Successfully refreshed token for profile "sandbox".

$ directus-cli auth refresh --profile sandbox   # refresh token rotates cleanly
Successfully refreshed token for profile "sandbox".

$ directus-cli collections get events --profile sandbox --quiet | jq .collection
"events"
```

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm lint` — 0 errors (2 pre-existing `max-len` warnings in `extensions/reinstall.ts` + `extensions/upgrade.ts`, unrelated)
- [x] `pnpm test` — 103/103 passing (98 existing + 5 new)
- [x] Manual refresh against two real Directus 11.16.1 instances
- [x] Manual refresh-token rotation (second refresh also succeeds)

Closes the real-world regression from #6.