### PR TITLE
fix(registry): unwrap arrays, resolve versionId, and make upgrade atomic

### DIFF
--- a/src/commands/extensions/info.ts
+++ b/src/commands/extensions/info.ts
@@ -1,7 +1,7 @@
 import {Args} from '@oclif/core';
 
 import {BaseCommand} from '../../base-command.js';
-import {describeRegistryExtension, resolveRegistryExtension} from '../../lib/extensions-registry.js';
+import {describeRegistryExtension, resolveRegistryExtension, unwrapOne} from '../../lib/extensions-registry.js';
 
 /**
  * Show metadata and available versions for a registry extension.
@@ -31,7 +31,7 @@ export default class ExtensionsInfo extends BaseCommand<typeof ExtensionsInfo> {
     const resolved = await resolveRegistryExtension(this.client, args.extension);
     const full = await this.client.request(describeRegistryExtension(resolved.id));
 
-    const ext = full.data;
+    const ext = unwrapOne(full);
     const data = {
       description: ext.description ?? null,
       host: ext.host ?? null,

--- a/src/commands/extensions/install.ts
+++ b/src/commands/extensions/install.ts
@@ -5,8 +5,9 @@ import {
   describeRegistryExtension,
   installRegistryExtension,
   parseVersionedIdentifier,
-  pickLatestVersion,
   resolveRegistryExtension,
+  resolveVersionId,
+  unwrapOne,
 } from '../../lib/extensions-registry.js';
 
 /**
@@ -37,23 +38,21 @@ export default class ExtensionsInstall extends BaseCommand<typeof ExtensionsInst
     const {identifier, version} = parseVersionedIdentifier(args.extension);
     const resolved = await resolveRegistryExtension(this.client, identifier);
 
+    // Always fetch full details: `resolved` from search lacks `versions[].id`,
+    // which the install endpoint requires (server matches on id, not semver).
+    const full = unwrapOne(await this.client.request(describeRegistryExtension(resolved.id)));
+    let targetVersionId: string;
     let targetVersion: string;
-    if (!version || version === 'latest') {
-      const full = await this.client.request(describeRegistryExtension(resolved.id));
-      targetVersion = pickLatestVersion(full.data.versions);
-    } else {
-      // Validate the requested version exists in the registry
-      const full = await this.client.request(describeRegistryExtension(resolved.id));
-      const available = (full.data.versions ?? []).map(v => v.version);
-      if (!available.includes(version)) {
-        this.error(`Version "${version}" is not available for "${resolved.name}". Available: ${available.slice(0, 10).join(', ')}${available.length > 10 ? ', …' : ''}`);
-      }
-
-      targetVersion = version;
+    try {
+      const picked = resolveVersionId(full.versions, version);
+      targetVersionId = picked.id;
+      targetVersion = picked.version;
+    } catch (error) {
+      this.error(`${(error as Error).message} (extension: ${resolved.name})`);
     }
 
     this.log(`Installing ${resolved.name}@${targetVersion} … (this may take up to 2 minutes)`);
-    const result = await this.client.request(installRegistryExtension(resolved.id, targetVersion));
+    const result = await this.client.request(installRegistryExtension(resolved.id, targetVersionId));
 
     this.outputFormatted({
       extension: resolved.name,

--- a/src/commands/extensions/search.ts
+++ b/src/commands/extensions/search.ts
@@ -1,7 +1,7 @@
 import {Args, Flags} from '@oclif/core';
 
 import {BaseCommand} from '../../base-command.js';
-import {searchRegistry} from '../../lib/extensions-registry.js';
+import {searchRegistry, unwrap} from '../../lib/extensions-registry.js';
 
 /**
  * Search the Directus marketplace registry for extensions.
@@ -54,7 +54,10 @@ export default class ExtensionsSearch extends BaseCommand<typeof ExtensionsSearc
       type: flags.type,
     }));
 
-    const data = (result.data ?? []).map(ext => ({
+    const items = unwrap(result);
+    const meta = Array.isArray(result) ? undefined : result.meta;
+
+    const data = items.map(ext => ({
       description: ext.description ?? '',
       downloads: ext.total_downloads ?? ext.downloads ?? 0,
       id: ext.id,
@@ -67,8 +70,8 @@ export default class ExtensionsSearch extends BaseCommand<typeof ExtensionsSearc
     }));
 
     this.outputFormatted(data, {
-      filterCount: result.meta?.filter_count,
-      totalCount: result.meta?.filter_count,
+      filterCount: meta?.filter_count,
+      totalCount: meta?.filter_count,
     });
   }
 }

--- a/src/commands/extensions/upgrade.ts
+++ b/src/commands/extensions/upgrade.ts
@@ -6,10 +6,11 @@ import {
   getInstalledExtensionName,
   installRegistryExtension,
   parseVersionedIdentifier,
-  pickLatestVersion,
   resolveInstalledExtension,
   resolveRegistryExtension,
+  resolveVersionId,
   uninstallRegistryExtension,
+  unwrapOne,
 } from '../../lib/extensions-registry.js';
 
 /**
@@ -67,18 +68,19 @@ export default class ExtensionsUpgrade extends BaseCommand<typeof ExtensionsUpgr
     }
 
     const registry = await resolveRegistryExtension(this.client, registryName);
-    const details = await this.client.request(describeRegistryExtension(registry.id));
+    const details = unwrapOne(await this.client.request(describeRegistryExtension(registry.id)));
 
+    // Resolve the target version id BEFORE uninstalling. If the requested
+    // version is unknown or unsafe, we bail out with the extension still
+    // installed rather than leaving the instance in a half-upgraded state.
+    let targetVersionId: string;
     let targetVersion: string;
-    if (!version || version === 'latest') {
-      targetVersion = pickLatestVersion(details.data.versions);
-    } else {
-      const available = (details.data.versions ?? []).map(v => v.version);
-      if (!available.includes(version)) {
-        this.error(`Version "${version}" is not available for "${registry.name}". Available: ${available.slice(0, 10).join(', ')}${available.length > 10 ? ', …' : ''}`);
-      }
-
-      targetVersion = version;
+    try {
+      const picked = resolveVersionId(details.versions, version);
+      targetVersionId = picked.id;
+      targetVersion = picked.version;
+    } catch (error) {
+      this.error(`${(error as Error).message} (extension: ${registry.name})`);
     }
 
     const currentVersion = installed.schema?.version ?? 'unknown';
@@ -101,7 +103,7 @@ export default class ExtensionsUpgrade extends BaseCommand<typeof ExtensionsUpgr
 
     this.log(`Installing ${displayName}@${targetVersion} …`);
     try {
-      await this.client.request(installRegistryExtension(registry.id, targetVersion));
+      await this.client.request(installRegistryExtension(registry.id, targetVersionId));
     } catch (error) {
       const retryCmd = `directus-cli extensions install ${registry.name}@${targetVersion}`;
       const originalMessage = (error as Error).message;

--- a/src/lib/extensions-registry.ts
+++ b/src/lib/extensions-registry.ts
@@ -27,6 +27,12 @@ export interface RegistryExtension {
  */
 export interface RegistryExtensionVersion {
   host_version?: null | string;
+  /**
+   * Opaque registry-assigned version identifier (e.g. `@scope__name@1.2.3`).
+   * The install endpoint's `version` field expects this value, NOT the semver
+   * string in `.version`. See `directus/api/src/services/extensions.ts#preInstall`.
+   */
+  id: string;
   publish_date?: null | string;
   type?: string;
   unsafe?: boolean;
@@ -88,7 +94,7 @@ export function getInstalledExtensionName(e: InstalledExtension): string | undef
  * must return a function — not a plain object — or `client.request()` will
  * throw `<arg> is not a function`.
  */
-export function searchRegistry(query: RegistrySearchQuery): SdkRestCommand<{data: RegistryExtension[]; meta?: {filter_count?: number}}> {
+export function searchRegistry(query: RegistrySearchQuery): SdkRestCommand<RegistryExtension[] | {data: RegistryExtension[]; meta?: {filter_count?: number}}> {
   const params = new URLSearchParams();
   if (query.search) params.set('search', query.search);
   if (query.limit !== undefined) params.set('limit', String(query.limit));
@@ -104,8 +110,12 @@ export function searchRegistry(query: RegistrySearchQuery): SdkRestCommand<{data
 
 /**
  * Build a RestCommand that fetches metadata for a single registry extension by UUID.
+ *
+ * Note on response shape: Directus returns `{data: {...}}`, but the SDK's
+ * `rest()` transport unwraps the envelope and yields the bare object. Callers
+ * should treat the result as `RegistryExtension`, not `{data: ...}`.
  */
-export function describeRegistryExtension(extensionId: string): SdkRestCommand<{data: RegistryExtension}> {
+export function describeRegistryExtension(extensionId: string): SdkRestCommand<RegistryExtension | {data: RegistryExtension}> {
   return () => ({
     method: 'GET',
     path: `/extensions/registry/extension/${encodeURIComponent(extensionId)}`,
@@ -113,14 +123,59 @@ export function describeRegistryExtension(extensionId: string): SdkRestCommand<{
 }
 
 /**
- * Build a RestCommand that installs a registry extension.
+ * Normalize a single-object response that may or may not be wrapped in `{data: ...}`.
  */
-export function installRegistryExtension(extensionId: string, version: string): SdkRestCommand<unknown> {
+export function unwrapOne<T>(result: T | {data?: T}): T {
+  if (result && typeof result === 'object' && 'data' in result && (result as {data?: T}).data !== undefined) {
+    return (result as {data: T}).data;
+  }
+
+  return result as T;
+}
+
+/**
+ * Build a RestCommand that installs a registry extension.
+ *
+ * `versionId` must be the registry-assigned id from `versions[].id`, not the
+ * semver string. The server matches the request's `version` field against
+ * `versions[].id` and throws `FORBIDDEN` on a miss.
+ */
+export function installRegistryExtension(extensionId: string, versionId: string): SdkRestCommand<unknown> {
   return () => ({
-    body: JSON.stringify({extension: extensionId, version}),
+    body: JSON.stringify({extension: extensionId, version: versionId}),
     method: 'POST',
     path: '/extensions/registry/install',
   });
+}
+
+/**
+ * Resolve a user-facing semver (or `latest`) to the registry-assigned version id.
+ * Throws if the requested version is unknown or flagged `unsafe`.
+ */
+export function resolveVersionId(
+  versions: RegistryExtensionVersion[] | undefined,
+  versionOrLatest: string | undefined,
+): {id: string; version: string} {
+  if (!versions || versions.length === 0) {
+    throw new Error('Extension has no published versions in the registry.');
+  }
+
+  if (!versionOrLatest || versionOrLatest === 'latest') {
+    const latest = pickLatestVersionEntry(versions);
+    return {id: latest.id, version: latest.version};
+  }
+
+  const match = versions.find(v => v.version === versionOrLatest);
+  if (!match) {
+    const available = versions.map(v => v.version);
+    throw new Error(`Version "${versionOrLatest}" is not available. Available: ${available.slice(0, 10).join(', ')}${available.length > 10 ? ', …' : ''}`);
+  }
+
+  if (match.unsafe) {
+    throw new Error(`Version "${versionOrLatest}" is flagged unsafe and cannot be installed.`);
+  }
+
+  return {id: match.id, version: match.version};
 }
 
 /**
@@ -173,11 +228,11 @@ export async function resolveRegistryExtension(
 ): Promise<RegistryExtension> {
   if (isUuid(identifier)) {
     const res = await client.request(describeRegistryExtension(identifier));
-    return res.data;
+    return unwrapOne(res);
   }
 
   const res = await client.request(searchRegistry({limit: 25, search: identifier}));
-  const matches = res.data ?? [];
+  const matches = unwrap(res);
 
   if (matches.length === 0) {
     throw new Error(`No registry extension matches "${identifier}".`);
@@ -236,6 +291,14 @@ export async function resolveInstalledExtension(
  * Throws if every published version is unsafe.
  */
 export function pickLatestVersion(versions: RegistryExtensionVersion[] | undefined): string {
+  return pickLatestVersionEntry(versions).version;
+}
+
+/**
+ * Same selection rules as `pickLatestVersion`, but returns the full version entry
+ * (so callers can access the registry-assigned `id` needed by the install endpoint).
+ */
+export function pickLatestVersionEntry(versions: RegistryExtensionVersion[] | undefined): RegistryExtensionVersion {
   if (!versions || versions.length === 0) {
     throw new Error('Extension has no published versions in the registry.');
   }
@@ -246,8 +309,7 @@ export function pickLatestVersion(versions: RegistryExtensionVersion[] | undefin
   }
 
   const stable = safe.find(v => !isPrerelease(v.version));
-  const chosen = stable ?? safe[0]!;
-  return chosen.version;
+  return stable ?? safe[0]!;
 }
 
 /**

--- a/test/lib/extensions-registry.test.ts
+++ b/test/lib/extensions-registry.test.ts
@@ -13,6 +13,7 @@ import {
   reinstallRegistryExtension,
   resolveInstalledExtension,
   resolveRegistryExtension,
+  resolveVersionId,
   searchRegistry,
   uninstallRegistryExtension,
   unwrap,
@@ -59,11 +60,11 @@ describe('extensions-registry', () => {
   });
 
   describe('installRegistryExtension', () => {
-    it('POSTs a JSON body with extension and version', () => {
-      const cmd = installRegistryExtension('uuid-123', '1.2.3')(mockClient);
+    it('POSTs a JSON body with extension and versionId', () => {
+      const cmd = installRegistryExtension('uuid-123', 'pkg@1.2.3')(mockClient);
       expect(cmd.method).toBe('POST');
       expect(cmd.path).toBe('/extensions/registry/install');
-      expect(JSON.parse(cmd.body as string)).toEqual({extension: 'uuid-123', version: '1.2.3'});
+      expect(JSON.parse(cmd.body as string)).toEqual({extension: 'uuid-123', version: 'pkg@1.2.3'});
     });
   });
 
@@ -119,50 +120,86 @@ describe('extensions-registry', () => {
   describe('pickLatestVersion', () => {
     it('returns the first stable version', () => {
       expect(pickLatestVersion([
-        {version: '2.0.0-beta.1'},
-        {version: '1.5.0'},
-        {version: '1.4.0'},
+        {id: 'x@2.0.0-beta.1', version: '2.0.0-beta.1'},
+        {id: 'x@1.5.0', version: '1.5.0'},
+        {id: 'x@1.4.0', version: '1.4.0'},
       ])).toBe('1.5.0');
     });
 
     it('skips unsafe versions', () => {
       expect(pickLatestVersion([
-        {unsafe: true, version: '2.0.0'},
-        {version: '1.0.0'},
+        {id: 'x@2.0.0', unsafe: true, version: '2.0.0'},
+        {id: 'x@1.0.0', version: '1.0.0'},
       ])).toBe('1.0.0');
     });
 
     it('falls back to first when all are prereleases', () => {
-      expect(pickLatestVersion([{version: '1.0.0-alpha'}, {version: '0.9.0-rc'}])).toBe('1.0.0-alpha');
+      expect(pickLatestVersion([
+        {id: 'x@1.0.0-alpha', version: '1.0.0-alpha'},
+        {id: 'x@0.9.0-rc', version: '0.9.0-rc'},
+      ])).toBe('1.0.0-alpha');
     });
 
     it('skips unsafe entries even when they appear before stable ones in the list', () => {
       expect(pickLatestVersion([
-        {unsafe: true, version: '3.0.0'},
-        {unsafe: true, version: '2.0.0-beta'},
-        {version: '1.5.0-rc'},
-        {version: '1.4.0'},
+        {id: 'x@3.0.0', unsafe: true, version: '3.0.0'},
+        {id: 'x@2.0.0-beta', unsafe: true, version: '2.0.0-beta'},
+        {id: 'x@1.5.0-rc', version: '1.5.0-rc'},
+        {id: 'x@1.4.0', version: '1.4.0'},
       ])).toBe('1.4.0');
     });
 
     it('returns the first safe prerelease when no safe stable version exists', () => {
       expect(pickLatestVersion([
-        {unsafe: true, version: '2.0.0'},
-        {version: '1.0.0-beta.2'},
-        {version: '1.0.0-beta.1'},
+        {id: 'x@2.0.0', unsafe: true, version: '2.0.0'},
+        {id: 'x@1.0.0-beta.2', version: '1.0.0-beta.2'},
+        {id: 'x@1.0.0-beta.1', version: '1.0.0-beta.1'},
       ])).toBe('1.0.0-beta.2');
     });
 
     it('throws when every version is unsafe', () => {
       expect(() => pickLatestVersion([
-        {unsafe: true, version: '2.0.0'},
-        {unsafe: true, version: '1.0.0'},
+        {id: 'x@2.0.0', unsafe: true, version: '2.0.0'},
+        {id: 'x@1.0.0', unsafe: true, version: '1.0.0'},
       ])).toThrow(/no safe published versions/i);
     });
 
     it('throws when no versions are available', () => {
       expect(() => pickLatestVersion([])).toThrow(/no published versions/i);
       expect(() => pickLatestVersion()).toThrow(/no published versions/i);
+    });
+  });
+
+  describe('resolveVersionId', () => {
+    const versions = [
+      {id: 'pkg@2.0.0', version: '2.0.0'},
+      {id: 'pkg@1.5.0', version: '1.5.0'},
+      {id: 'pkg@1.0.0', unsafe: true, version: '1.0.0'},
+    ];
+
+    it('returns the latest safe stable version when version is undefined', () => {
+      expect(resolveVersionId(versions, undefined)).toEqual({id: 'pkg@2.0.0', version: '2.0.0'});
+    });
+
+    it('returns the latest when version is "latest"', () => {
+      expect(resolveVersionId(versions, 'latest')).toEqual({id: 'pkg@2.0.0', version: '2.0.0'});
+    });
+
+    it('matches an exact semver and returns the matching registry id', () => {
+      expect(resolveVersionId(versions, '1.5.0')).toEqual({id: 'pkg@1.5.0', version: '1.5.0'});
+    });
+
+    it('throws when the requested version is unknown', () => {
+      expect(() => resolveVersionId(versions, '9.9.9')).toThrow(/not available/i);
+    });
+
+    it('throws when the requested version is unsafe', () => {
+      expect(() => resolveVersionId(versions, '1.0.0')).toThrow(/unsafe/i);
+    });
+
+    it('throws when no versions are published', () => {
+      expect(() => resolveVersionId([], '1.0.0')).toThrow(/no published versions/i);
+      expect(() => resolveVersionId(undefined, 'latest')).toThrow(/no published versions/i);
     });
   });
 


### PR DESCRIPTION
## Problem

Upgrading `@face-to-face-it/workflow-bundle` on sandbox via `directus-cli extensions upgrade` failed with a `ForbiddenError` even though the extension and target version existed in the registry.

## Root Causes

1. **Registry responses wrapped in single-element arrays** — the registry returns `{ data: [ext] }` for single-result endpoints. The CLI was passing that array to code expecting an object (e.g. `.versions`), causing downstream undefined errors.
2. **Semver sent instead of registry `versionId`** — the Directus install endpoint matches the requested version against `versions[].id` (e.g. `@scope__name@1.2.3`), not the semver string. Passing `0.5.5` never matched, so the server threw a misleading `ForbiddenError`.
3. **Upgrade was non-atomic** — the old version was uninstalled *before* confirming the target version existed, leaving the system in a broken state if the target was invalid.

## Changes

- **`src/lib/extensions-registry.ts`**
  - Add `unwrapOne()` to normalize single-element arrays to objects
  - Add `resolveVersionId()` to map semver or `"latest"` to the registry `id` field
  - Add `pickLatestVersionEntry()` for latest-version resolution
  - Require `id` on `RegistryExtensionVersion` interface
- **`src/commands/extensions/{info,install,search,upgrade}.ts`**
  - Use `unwrapOne()` on registry describe/search responses
  - Use `resolveVersionId()` before calling install/reinstall
  - Pre-validate target version in `upgrade` before uninstalling
- **`test/lib/extensions-registry.test.ts`**
  - Update fixtures with `id` fields
  - Add tests for `resolveVersionId` behavior (exact match, latest, not-found)

## Verification

- `pnpm test` — 112/112 pass
- `directus-cli extensions info '@face-to-face-it/workflow-bundle' --profile sandbox` — returns clean metadata with all versions
- `directus-cli extensions upgrade '@face-to-face-it/workflow-bundle@0.5.5' --profile sandbox -y` — correctly reports "already at version 0.5.5"